### PR TITLE
Promote carolynvs to admin.  Drop gerred to contributor.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -23,19 +23,19 @@ collaborators:
   - username: jberkus
     permission: admin
 
-  - username: gerred
-    permission: push
-
   - username: parispittman
     permission: admin
 
   - username: idvoretskyi
     permission: admin
+    
+  - username: carolynvs
+    permission: admin
 
     # Contributors
     # all permissions except admin
-
-  - username: carolynvs
+    
+  - username: gerred
     permission: push
 
   - username: mattklein123


### PR DESCRIPTION
Now that @carolynvs is officially our TL, change her perms.

@parispittman or @justaugustus please approve, thanks!