### PR TITLE
Rename default branch to main

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -4,6 +4,9 @@ repository:
   # The name of the repository. Changing this will rename the repository
   name: tag-contributor-strategy
 
+  # Updates the default branch for this repository.
+  default_branch: main
+
   # A short description of the repository that will show up on GitHub
   description: CNCF Technical Advisory Group on Contributor Strategy -- maintainer relations, building up contributors, governance, graduation, and more.
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,7 +2,7 @@ name: Sync Staging
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   sync-staging:
@@ -14,6 +14,6 @@ jobs:
         uses: devmasx/merge-branch@v1.3.1
         with:
           type: now
-          from_branch: master
+          from_branch: main
           target_branch: staging
           github_token: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,9 +94,9 @@ heard from us in 5 days.
 squash them for you.
 - If a member asks you to "rebase" your PR, they're saying that a lot of docs/code
  has changed, and that you need to update your branch to incorporate the latest
- changes from master before we can merge your PR. You can use whatever you are
- comfortable with, either merging master into your branch or rebasing your
- branch on master.
+ changes from main before we can merge your PR. You can use whatever you are
+ comfortable with, either merging main into your branch or rebasing your
+ branch on main.
 #### Reviewers:
 - We leave pull requests open for at least 48 hours, so that others have the
 chance to review/comment except in cases of the following:
@@ -118,16 +118,16 @@ https://www.firsttimersonly.com/
 
 
 [CNCF’s code of conduct]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
-[communication channels]: https://github.com/cncf/sig-contributor-strategy/blob/master/README.md#communications
+[communication channels]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md#communications
 [TOC]: https://www.cncf.io/people/technical-oversight-committee/
 [SIG]: https://github.com/cncf/toc/tree/master/sigs
-[README]: https://github.com/cncf/sig-contributor-strategy/blob/master/README.md
-[charter]: https://github.com/cncf/sig-contributor-strategy/blob/master/CHARTER.md
-[working groups]: https://github.com/cncf/sig-contributor-strategy/blob/master/README.md#working-groups
+[README]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md
+[charter]: https://github.com/cncf/tag-contributor-strategy/blob/main/CHARTER.md
+[working groups]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md#working-groups
 [cncf/contribute]: https://github.com/cncf/contribute
 [cncf/sig-contributor-strategy]: https://github.com/cncf/sig-contributor-strategy
 [maintainers circle]: https://github.com/cncf/sig-contributor-strategy/issues/1
-[4th Thursday meeting of each month]: https://github.com/cncf/sig-contributor-strategy/blob/master/README.md#meetings
+[4th Thursday meeting of each month]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md#meetings
 [website/content]: website/content/
 [contributing guide]: https://cncf-contribute.netlify.app/about/contributing/
 [maintainers]: https://cncf-contribute.netlify.app/maintainers

--- a/resources.md
+++ b/resources.md
@@ -49,7 +49,7 @@ Serve as a quick resource for the SIG to grab links that we work with at high fr
 - [Nayafia's template from researching a ton of open source projects](https://github.com/nayafia/contributing-template/blob/master/CONTRIBUTING-template.md)
 - [GoodDocs: aiming to help projects with good templates](https://thegooddocsproject.dev/contribute.html)
 - [Athens Contributing Guide](https://github.com/gomods/athens/blob/master/CONTRIBUTING.md)
-- [Porter Contributing Guide](https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md)
+- [Porter Contributing Guide](https://github.com/getporter/porter/blob/main/CONTRIBUTING.md)
 - [Open Policy Agent Contributing Guide](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md#code-review)
 
 ## Maintainer/Core Contributor Advice

--- a/website/config.toml
+++ b/website/config.toml
@@ -160,7 +160,7 @@ prism_syntax_highlighting = false
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 [params.github]
   repo = "https://github.com/cncf/sig-contributor-strategy"
-  branch = "master"
+  branch = "main"
   subdir = "website"
 
   [params.github.contributors]

--- a/website/content/maintainers/github/templates.md
+++ b/website/content/maintainers/github/templates.md
@@ -39,5 +39,5 @@ when you view the markdown file in GitHub unless you view the raw text.
 * [CONTRIBUTOR_LADDER.md](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md)
 * [GOVERNANCE.md](https://github.com/cncf/project-template/blob/main/GOVERNANCE.md)
 
-[contrib-strat]: https://github.com/cncf/sig-contributor-strategy/blob/master/README.md
+[contrib-strat]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md
 [project template]: https://github.com/cncf/project-template

--- a/website/content/maintainers/governance/paperwork-checklist.md
+++ b/website/content/maintainers/governance/paperwork-checklist.md
@@ -15,7 +15,7 @@ reference if your project is planning to join the CNCF or graduate levels.
 
 *   Requirements:
     *   [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
-        *   [Template](https://github.com/cncf/project-template/blob/master/CODE_OF_CONDUCT.md)
+        *   [Template](https://github.com/cncf/project-template/blob/main/CODE_OF_CONDUCT.md)
         *   Decide if COC enforcement will be handled by the project or by the CNCF
             *   CNCF is a good option for young/small projects.  They will provide contact.
         *   If handling it yourself: decide who are the contacts and how to deal with a maintainer being reported, or a contact being reported. Need more than one contact.
@@ -23,10 +23,10 @@ reference if your project is planning to join the CNCF or graduate levels.
             *   If the COC enforcement body is your maintainers, then you need to have a policy to escalate to CNCF if the report is against a maintainer.
     *   Adhere to [CNCF IP Policy](https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy)
     *   CONTRIBUTING.md containing basic “how to contribute” ([Harbor example](https://github.com/goharbor/harbor/blob/master/CONTRIBUTING.md))
-        *   [Template](https://github.com/cncf/project-template/blob/master/CONTRIBUTING.md)
+        *   [Template](https://github.com/cncf/project-template/blob/main/CONTRIBUTING.md)
     *   Light project roadmap, at least an easily findable list of TODO items or issues
     *   LICENSE
-        *   [Template](https://github.com/cncf/project-template/blob/master/LICENSE)
+        *   [Template](https://github.com/cncf/project-template/blob/main/LICENSE)
             *   You need to edit "Copyright [yyyy] [name of copyright owner]".
             *   Replace [yyyy] with the current year.
             *   Replace [name of copyright owner] with "The PROJECT Authors", e.g. "The Kubernetes Authors" or "The Helm Authors".
@@ -40,7 +40,7 @@ reference if your project is planning to join the CNCF or graduate levels.
 ## Entering Incubation
 
 *   Additional Requirements:
-    *   Governance.md showing the leaders and [how they are selected](https://github.com/cncf/sig-contributor-strategy/blob/master/governance/docs/leadership_selection.md)
+    *   Governance.md showing the leaders and [how they are selected](https://contribute.cncf.io/maintainers/governance/leadership-selection/)
         *   Include full election docs if there are elections
         *   Governance process must be employer-neutral
     *   File showing who the end users are

--- a/website/layouts/partials/page-meta-links.html
+++ b/website/layouts/partials/page-meta-links.html
@@ -8,7 +8,7 @@
 {{ $gh_repo := index $github "repo" }}
 {{ $gh_subdir := index $github "subdir" }}
 {{ $gh_project_repo := index $github "project_repo" }}
-{{ $gh_branch := (default "master" (index $github "branch")) }}
+{{ $gh_branch := (default "main" (index $github "branch")) }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
 {{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted }}


### PR DESCRIPTION
This changes the default branch for this repository from master to main. There is also a corresponding [change](https://github.com/cncf/contribute/pull/57) to the cncf/contribute repository to change which branch it uses a Netlify webhook to trigger builds. The two pull requests do not need to be timed very closely since I have already cloned the master branch and named it main. Either can be merged first.

I found a few URLs that were still using sig instead of tag in the repo, so I fixed them as well so we aren't relying on github's redirects.
