### PR TITLE
Publish the Contributor Growth Framework

### DIFF
--- a/website/content/maintainers/community/contributor-growth-framework/_index.md
+++ b/website/content/maintainers/community/contributor-growth-framework/_index.md
@@ -2,7 +2,6 @@
 title: "Contributor Growth"
 date: 2020-02-26
 layout: single
-draft: true
 description: >
   A framework to help open source projects develop workflows, processes, and habits that 
   incentivize users to become long-term, active, and engaged members of your community.

--- a/website/content/maintainers/community/contributor-growth-framework/engagement.md
+++ b/website/content/maintainers/community/contributor-growth-framework/engagement.md
@@ -3,7 +3,6 @@ title: "Keeping contributors engaged after their first contribution"
 linkTitle: "Engagement"
 date: 2021-04-8
 weight: 3
-draft: true
 ---
 
 To keep contributors engaged, the human element is important. Building a warm and fuzzy environment spreads like wildfire. While it may sound obvious, it's easy to forget, so make sure you:  

--- a/website/content/maintainers/community/contributor-growth-framework/incentivizing-contributors.md
+++ b/website/content/maintainers/community/contributor-growth-framework/incentivizing-contributors.md
@@ -3,7 +3,6 @@ title: "Incentivizing contributors to move up the ladder"
 linkTitle: "Incentivizing Contributors"
 date: 2021-04-8
 weight: 4
-draft: true
 ---
 
 By developing a contributor ladder and describing roles, responsibilities, privileges, and the level of effort associated with each, contributors get a sense of what it means to be part of your community at various levels. Just like in their professional careers, understanding the different paths and what it takes to get there can be motivating.   

--- a/website/content/maintainers/community/contributor-growth-framework/incentivizing-non-code.md
+++ b/website/content/maintainers/community/contributor-growth-framework/incentivizing-non-code.md
@@ -3,7 +3,6 @@ title: "Incentivizing non-code contributions"
 linkTitle: "Non-Code Contributors"
 date: 2021-04-8
 weight: 5
-draft: true
 ---
 
 While swag and awards can motivate community members to help others or share their stories, that strategy doesn't scale and is only feasible for small projects. It certainly is a good tool for projects earlier in their journey.  

--- a/website/content/maintainers/community/contributor-growth-framework/incentivizing-non-code.md
+++ b/website/content/maintainers/community/contributor-growth-framework/incentivizing-non-code.md
@@ -21,7 +21,7 @@ To request content, consider creating a GitHub issue asking for blog posts. Cont
 
 ## Long-term contributors
 
-But you also want more permanent non-code contributions. Think filing issues, tech writers, PXMs, testing, or product managers, all have a great skill set your project can benefit from. Unfortunately, most of these people don't really know that they, too, can be active members of the open source community.
+But you also want more permanent non-code contributions. Think filing issues, QA, tech writers, PXMs, testing, or product managers, all have a great skill set your project can benefit from. Unfortunately, most of these people don't really know that they, too, can be active members of the open source community.
 
 Make these roles known and give people a hat so they know their contribution is valuable. That will also help prove to their employer that their work is valued. Even if the hat feels ceremonial to you, it may give them the business case to work on that project.
 For these types of roles, the term "contributor ladder" isn't helpful. While for code contributions it really is more of a ladder where you get increasingly more responsibilities and privileges, these non-code contributor roles are more like different buckets with every different – but just as important – skill sets.

--- a/website/content/maintainers/community/contributor-growth-framework/incentivizing-non-code.md
+++ b/website/content/maintainers/community/contributor-growth-framework/incentivizing-non-code.md
@@ -21,7 +21,7 @@ To request content, consider creating a GitHub issue asking for blog posts. Cont
 
 ## Long-term contributors
 
-But you also want more permanent non-code contributions. Think tech writers, PXMs, or product managers, all have a great skill set your project can benefit from. Unfortunately, most of these people don't really know that they, too, can be active members of the open source community.
+But you also want more permanent non-code contributions. Think filing issues, tech writers, PXMs, testing, or product managers, all have a great skill set your project can benefit from. Unfortunately, most of these people don't really know that they, too, can be active members of the open source community.
 
 Make these roles known and give people a hat so they know their contribution is valuable. That will also help prove to their employer that their work is valued. Even if the hat feels ceremonial to you, it may give them the business case to work on that project.
 For these types of roles, the term "contributor ladder" isn't helpful. While for code contributions it really is more of a ladder where you get increasingly more responsibilities and privileges, these non-code contributor roles are more like different buckets with every different – but just as important – skill sets.

--- a/website/content/maintainers/community/contributor-growth-framework/long-term-contributors.md
+++ b/website/content/maintainers/community/contributor-growth-framework/long-term-contributors.md
@@ -3,7 +3,6 @@ title: "Long-term contributors"
 linkTitle: "Long-term Contributors"
 date: 2021-04-8
 weight: 6
-draft: true
 ---
 
 But you also want more permanent non-code contributions. Think tech writers, PXMs, or product managers, all have a great skill set your project can benefit from. Unfortunately, most of these people don't really know that they, too, can be active members of the open source community.  

--- a/website/content/maintainers/community/contributor-growth-framework/motivation.md
+++ b/website/content/maintainers/community/contributor-growth-framework/motivation.md
@@ -2,7 +2,6 @@
 title: "Motivating users to contribute"
 linkTitle: "Motivation"
 date: 2020-03-15
-draft: true
 weight: 1
 description: >
    Identify what motivates your users to contribute and how you can encourage more people to contribute.

--- a/website/content/maintainers/community/contributor-growth-framework/motivation.md
+++ b/website/content/maintainers/community/contributor-growth-framework/motivation.md
@@ -66,14 +66,7 @@ Also, consider how someone on Windows should build and run the project locally. 
 If your project has external dependencies, Docker Compose is a great tool.  It allows you to put a database into a Docker Compose file, and let the contributor run docker-compose up. 
 And make sure everything is well documented in your docs and/or video tutorials. No matter how trivial a step is, if it's part of the process, document it. Remember that friction is dangerous, so always ask yourself "can I make this easier?"  
 
-Examples of tools that help minimize PR submission process
-Tool | What it does
----|---
-Tilt | Automate a lot of otherwise manual steps to get developers up and running, significantly improving the contributor experience.
-Docker compose | To put dependencies in a Docker Compose file
-docker | To run docker containers locally or to create a consistent development environment  
-VSCode, IntelliJ IDEA, etc. | An editor that does syntax highlighting and catches errors will save you a ton of time. If you can provide workspace definition files that will configure their existing IDE installations around your codebase, that will drastically reduce friction
-  
+Some examples of tools that minimize the PR submission process would be: linters, IDE plugins for your programming language or tech stack, or using Docker to automate developer environment setup.
   
 # The Human Factor
 

--- a/website/content/maintainers/community/contributor-growth-framework/pr-workflow.md
+++ b/website/content/maintainers/community/contributor-growth-framework/pr-workflow.md
@@ -3,7 +3,6 @@ title: "A successful PR workflow"
 linkTitle: "PR Workflow"
 date: 2020-03-29
 weight: 2
-draft: true
 description: >
    Develop a welcoming pull request workflow that sets contributors up for success.
 ---

--- a/website/content/maintainers/community/contributor-growth-framework/pr-workflow.md
+++ b/website/content/maintainers/community/contributor-growth-framework/pr-workflow.md
@@ -10,7 +10,7 @@ description: >
 The PR workflow is at the core of code contributions. Make sure it's a smooth experience, automate as much as possible (bots can be really helpful), and try to get contributors to contribute something else after successfully submitting a PR. 
 
 Here's a typical PR workflow: 
-   1. **User opens an issue** (bug, feature request, vulnerability): As maintainers, you will first troubleshoot the bug or review the feature request. Reach out to the submitter to thank them for the issue and assess if they want to be involved. If they are, ask them to continue the conversation on your contributor channel. 
+   1. **User opens an issue** (bug or feature request): As maintainers, you will first troubleshoot the bug or review the feature request. Reach out to the submitter to thank them for the issue and assess if they want to be involved. If they are, ask them to continue the conversation on your contributor channel. For vulnerabilities, projects should adopt the processes outlined by [TAG Security](https://github.com/cncf/tag-security/tree/main/project-resources), so that projects can accept security reports privately and address them before they are disclosed publicly. 
 
    2. **Pick conversation up on contributor channel**:  
 Consider assigning new contributors to a mentor or point of contact who can follow up making sure they remain motivated and follow through (may not always be possible due to time constraints). Community CRMs will help you keep track of contributor activity. If you don't see any activity from your prospective contributor, check-in to see if they are still interested. A gentle reminder may revive their motivation and show them you really care about their contribution. 


### PR DESCRIPTION
Remove the draft flag so that the Contributor Growth Framework is visible on the live site, contribute.cncf.io.

Preview at https://deploy-preview-116--cncf-contribute.netlify.app/maintainers/community/contributor-growth-framework/
