### PR TITLE
Add needs-toc-approval label

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -76,6 +76,9 @@ labels:
     color: 00ffff
   - name: wg/contribgrowth
     color: ff00ff
+  - name: needs-toc-approval
+    description: Requires approval from the TOC before merging to main
+    color: b60205
 
 # additional colors in this palette:
 # 7f0000 , 1e90ff, ffdab9, ff69b4


### PR DESCRIPTION
Add a label to indicate that a PR should not be merged until it has been approved by the TOC.
