### PR TITLE
Contributor Growth Framework - minor cleanup

### DIFF
--- a/website/content/maintainers/community/contributor-growth-framework/engagement.md
+++ b/website/content/maintainers/community/contributor-growth-framework/engagement.md
@@ -7,11 +7,11 @@ draft: true
 ---
 
 To keep contributors engaged, the human element is important. Building a warm and fuzzy environment spreads like wildfire. While it may sound obvious, it's easy to forget, so make sure you:  
-  1. Thank contributors publicly and privately (some community CRMs auto populate a thank you tweet and email for first PRs)
+  1. Thank contributors publicly and privately (some community CRMs auto populate a thank you tweet and email for first PRs).
   2. Engage them in a conversation on Slack and show interest by asking questions about their project, their interest, etc.  
   3. Suggest the next step when reviewing their PR. 
   4. Invite them to join your next community meeting to introduce themselves.
-  5. Shout out during community meeting  
+  5. Shout out during community meeting.
   6. Develop recognition programs.  
 
 Each PR can potentially lead to something else. Maybe it's part of a larger goal or will lead to an easy next step of a contribution. Have those conversations and try to guide contributors so they continue building on their work.  

--- a/website/content/maintainers/community/contributor-growth-framework/incentivizing-non-code.md
+++ b/website/content/maintainers/community/contributor-growth-framework/incentivizing-non-code.md
@@ -8,24 +8,15 @@ draft: true
 
 While swag and awards can motivate community members to help others or share their stories, that strategy doesn't scale and is only feasible for small projects. It certainly is a good tool for projects earlier in their journey.  
 
-Consciously create an environment where learning in public is ok. This includes, public office hours, unboxing sessions, live streams where you figure out how to do something together.  
+Consciously create an environment where learning in public is ok. This includes public office hours, unboxing sessions, and live streams where you figure out how to do something together.  
 
 Foster a Q&A culture where people feel comfortable to just jump in. Tag others familiar with a topic in conversations so they can chime in. This has two effects: 1) you publicly recognize the person as an expert and let them know that you value their opinion, and 2) everyone sees that it's not only the role of the maintainers to help out.  
 
 Especially for large projects, Slack can get messy quickly. If it's too noisy, people won't engage. Create topic specific Slack channels where it's easier to follow conversations they care about.  
 
-Non-code contributor roles such as moderators, community managers, and documentation maintainers should be part of your [ladder]. They can ask (loaded) questions in chats to seed discussions. Post helpful, curated content and links. While you can't ask people to answer questions, if the channel is not super high vol and/or specific to their interest, they'll answer.  
+Non-code contributor roles such as moderators, community managers, and documentation maintainers should be part of your [ladder]. They can ask (loaded) questions in chats to seed discussions, and post helpful, curated content and links. While you can't ask people to answer questions, if the channel is not super high volume and/or specific to their interest, they'll answer.  
 
 To request content, consider creating a GitHub issue asking for blog posts. Contributors can send their links which you can tweet out. You'll need a community manager to keep track of this, though.
 
 [ladder]: https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md
-
-## Long-term contributors
-
-But you also want more permanent non-code contributions. Think tech writers, PXMs, or product managers, all have a great skill set your project can benefit from. Unfortunately, most of these people don't really know that they, too, can be active members of the open source community.
-
-Make these roles known and give people a hat so they know their contribution is valuable. That will also help prove to their employer that their work is valued. Even if the hat feels ceremonial to you, it may give them the business case to work on that project.
-For these types of roles, the term "contributor ladder" isn't helpful. While for code contributions it really is more of a ladder where you get increasingly more responsibilities and privileges, these non-code contributor roles are more like different buckets with every different – but just as important – skill sets.
-
-For larger projects, different governance groups also fall under this category. The steering committee and various subcommittees all have very different skill sets that your project can benefit from.
 

--- a/website/content/maintainers/community/contributor-growth-framework/long-term-contributors.md
+++ b/website/content/maintainers/community/contributor-growth-framework/long-term-contributors.md
@@ -9,6 +9,7 @@ draft: true
 But you also want more permanent non-code contributions. Think tech writers, PXMs, or product managers, all have a great skill set your project can benefit from. Unfortunately, most of these people don't really know that they, too, can be active members of the open source community.  
 
 Make these roles known and give people a hat so they know their contribution is valuable. That will also help prove to their employer that their work is valued. Even if the hat feels ceremonial to you, it may give them the business case to work on that project.  
+
 For these types of roles, the term "contributor ladder" isn't helpful. While for code contributions it really is more of a ladder where you get increasingly more responsibilities and privileges, these non-code contributor roles are more like different buckets with every different – but just as important – skill sets.  
 
 For larger projects, different governance groups also fall under this category. The steering committee and various subcommittees all have very different skill sets that your project can benefit from.  

--- a/website/content/maintainers/community/contributor-growth-framework/motivation.md
+++ b/website/content/maintainers/community/contributor-growth-framework/motivation.md
@@ -33,7 +33,7 @@ When you discuss the roadmap, make sure it's all discussed publicly (e.g. commun
 
 Be clear and descriptive about how people can get involved and document it well. Good "first issues" and "help wanted" labels are great ways to signal how people can get started (for guidance on curating your good first issues [please refer to this doc)](/maintainers/github/issue-labels/). It also shows that the maintainers have taken the time to identify how newcomers can help.  But also be explicit about what you need and communicate it where your users are (e.g. Twitter, Slack, tech blogs, docs, releases).  
 
-The more descriptive, the better. While telling contributors " just to jump in" may be easy, it can also be really overwhelming. Taking the time to describe what you need and how you need it is time-consuming, but it will also save you time down the line as people start work on things you need the way you specified them, reducing backs and forth. By describing the "what" and "how" of what you need, you are onboarding new contributors and empowering them to help other potential contributors. 
+The more descriptive, the better. While telling contributors "just to jump in" may be easy, it can also be really overwhelming. Taking the time to describe what you need and how you need it is time-consuming, but it will also save you time down the line as people start work on things you need the way you specified them, reducing backs and forth. By describing the "what" and "how" of what you need, you are onboarding new contributors and empowering them to help other potential contributors. 
 
 An adopters list lets people know who's using your project. Big company names always help instill confidence but may also signal people working at these companies that they could get more involved, maybe even become a maintainer. 
 More mature projects should take advantage of end-user committees. Generally composed of a diverse group of decision-makers, building relationships with your end-users and getting input on what they would like to see on the roadmap is incredibly valuable. 
@@ -43,7 +43,7 @@ More mature projects should take advantage of end-user committees. Generally com
 Motivation to contribute can be gone as quickly as it appeared. To ensure prospective contributors remain motivated, eliminate as much friction as possible. As mentioned above, each additional step represents an additional friction point and a possible drop-off. Make sure the entire contributor experience is intuitive and easy, including:
    * Running the code locally before opening a PR (e.g. providing a Makefile and test data on top of instructions to build and run it)
    * Automated testing during PR process
-   * Clear PR submission requirements (e.g. Contributor License Agreement, Digital Certificate of Origin)
+   * Clear PR submission requirements (e.g. Contributor License Agreement, Developer Certificate of Origin)
    * Submitting the PR (and be sure to set the expectations right regarding wait time, but more to that below)
 
 ### Documentation
@@ -71,8 +71,8 @@ Examples of tools that help minimize PR submission process
 Tool | What it does
 ---|---
 Tilt | Automate a lot of otherwise manual steps to get developers up and running, significantly improving the contributor experience.
-Docker compose | To put dependencies in a Docker Compose file
-docker | To run docker containers locally or to create a consistent development environment  
+Docker Compose | To put dependencies in a Docker Compose file
+Docker | To run docker containers locally or to create a consistent development environment  
 VSCode, IntelliJ IDEA, etc. | An editor that does syntax highlighting and catches errors will save you a ton of time. If you can provide workspace definition files that will configure their existing IDE installations around your codebase, that will drastically reduce friction
   
   
@@ -92,7 +92,7 @@ Here are some best practices when using a community CRM:
 
 **Capture everything that is relevant:** If someone is interested in a particular tech or subproject, add that in the notes section of their profile. If they continuously engage in the subproject or conversations around it, add a tag. 
 
-Is a community member interested in speaking at events or writing blogs? Maybe someone expressed interest in working on a particular feature or taking the next step in the contributor ladder six months from now. Combine that with tasks so you remember to follow-up. 
+Is a community member interested in speaking at events or writing blog posts? Maybe someone expressed interest in working on a particular feature or taking the next step in the contributor ladder six months from now. Combine that with tasks so you remember to follow-up. 
 You can even track things like who received what swag, ensuring you don't resend the same goodie twice.  
 
 1. **Leverage "tasks" for anything that needs a follow up:** Whether a blog post someone wanted to write or additional info you promised to provide. If it's an action item and you won't tackle it right away, create a task.
@@ -100,11 +100,11 @@ You can even track things like who received what swag, ensuring you don't resend
 4. **Use tags:** Tags can be based on interest, subprojects, or whatever makes sense for your project. Let's say you want to find contributors for your next observability feature on the roadmap. If used correctly, tags allow you to identify everyone who's expressed interest in that area.   
 
 These CRMs do lots of cool stuff. Savannah, for instance, allows you to see the impact your swag has on contributor productivity. 
-Another open source CNCF project is the [CHAOSS Project](https://chaoss.community/about/) which provides guidelines and processes for measuring the health of a community. It's not necessary to use CHAOSS or its principles for your project, but it is good to consider the overall health of your community and what you will use to measure that health as the community grows.  
+Another open source CNCF project is the [CHAOSS Project](https://chaoss.community/about/), which is not a CRM, but it does provide metrics, guidelines, and processes for measuring the health of a community. It's not necessary to use CHAOSS or its principles for your project, but it is good to consider the overall [health of your community](/maintainers/community/project-health/) and what you will use to measure that health as the community grows.  
 
 Tool | What it does
 ---|---
-Chaoss | The Augur and Grimoire Lab projects can be integrated with the GitHub repositories for your project to view the commits and people who are making those commits over time.
+Augur and GrimoireLab | These CHAOSS projects can be integrated with most community tools, including your GitLab / GitHub repositories for your project to view the commits and people who are making those commits over time.
 Savannah | Community CRM with GitHub, GitLab, Slack, Discourse, Discord, Stack Exchange integration
 Orbit | Community CRM with Discourse, GitHub, and Twitter, Slack (beta) integration.   
 

--- a/website/content/maintainers/community/contributor-growth-framework/pr-workflow.md
+++ b/website/content/maintainers/community/contributor-growth-framework/pr-workflow.md
@@ -16,7 +16,7 @@ Here's a typical PR workflow:
    2. **Pick conversation up on contributor channel**:  
 Consider assigning new contributors to a mentor or point of contact who can follow up making sure they remain motivated and follow through (may not always be possible due to time constraints). Community CRMs will help you keep track of contributor activity. If you don't see any activity from your prospective contributor, check-in to see if they are still interested. A gentle reminder may revive their motivation and show them you really care about their contribution. 
 
-   3. **Submit one PR**:Once they submitted their PR, suggest another contribution or, if they have been contributing for a while, ask them if they'd like to take the next step and move up the contributor ladder.  
+   3. **Submit one PR**: Once they submitted their PR, suggest another contribution or, if they have been contributing for a while, ask them if they'd like to take the next step and move up the contributor ladder.  
 
 This is really key. If you want people to engage more or take on more responsibility, you have to encourage them to do so. It's a little bit like a career coach (don't forget to take notes in your community CRM about their preferences, time restrictions, etc. Having that info at hand will prove useful during future conversations). While guiding people is a lot of work and you may think you don't have time to do so, it will save you a lot of time down the line. 
 
@@ -42,14 +42,15 @@ Loop contributors into issues when you know that they are interested in that par
 
 ## Providing Sufficient Contributor Tools
 
-To incentivize contributions, you need more than just a contributor guide; you need a toolkit. But don't overdo it. If you have too many resources, you may overwhelm them. Here are a few examples. Identify what makes most sense for your project and what you'll be able to maintain (and retire old material not to confuse them). 
+To incentivize contributions, you need more than just a contributor guide; you need a toolkit. But don't overdo it. If you have too many resources, you may overwhelm them. Here are a few examples. Identify what makes most sense for your project and what you'll be able to maintain (and retire old material to avoid confusion). 
 
    * Comprehensive docs 
    * PR checklist  
    * Templates  
    * Hello World 
    * Code walkthroughs (videos, docs, etc.)
-   * [Contributor ladder]/"a day in the life of a maintainer" description 
+   * [Contributor ladder]
+   * "A day in the life of a maintainer" description 
 
 ***On demand videos:*** Contributing 101, guideline videos. These can be served through [automated bots](https://github.com/hoodiehq/first-timers-bot) (e.g.  "hey, I see you are a first-time contributor. Check out this video on how to successfully submit a PR").  
 


### PR DESCRIPTION
I fixed a few typos throughout this section. 

There were 2 significant changes:
* Removed the section about long-term contributors from incentivizing-non-code.md, since it was duplicated in long-term-contributors.md
* Corrected some of the content about CHAOSS in motivation.md