### PR TITLE
Do not show page modified when empty

### DIFF
--- a/website/layouts/partials/page-meta-lastmod.html
+++ b/website/layouts/partials/page-meta-lastmod.html
@@ -1,0 +1,3 @@
+{{ if isset .Params "lastmod" }}
+{{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
+{{ end }}


### PR DESCRIPTION
When the last modified date of a page cannot be determined, i.e. due to this missing feature in Hugo, do not show that template in the page footer.

See https://github.com/gohugoio/hugo/issues/5533

Fixes https://github.com/cncf/contribute/issues/59
