### PR TITLE
Last Modified page leads to Error 404

### DIFF
--- a/website/layouts/partials/page-meta-lastmod.html
+++ b/website/layouts/partials/page-meta-lastmod.html
@@ -1,3 +1,3 @@
 {{ if isset .Params "lastmod" }}
-{{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
+{{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: {{ .Subject }} {{end }}
 {{ end }}


### PR DESCRIPTION
Last modified page lead to error page and it shows
Not found
Oops! This page doesn't exist. Try going back to our home page.

What I changed:
I removed the href tag leading to error page. 
Now, People will see what changes were made but on clicking it won't lead to error page.