### PR TITLE
Fix link to the last modified commit page

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -159,7 +159,7 @@ prism_syntax_highlighting = false
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 [params.github]
-  repo = "https://github.com/cncf/sig-contributor-strategy"
+  repo = "https://github.com/cncf/tag-contributor-strategy"
   branch = "main"
   subdir = "website"
 

--- a/website/layouts/partials/page-meta-lastmod.html
+++ b/website/layouts/partials/page-meta-lastmod.html
@@ -1,3 +1,13 @@
+{{ if .Path }}
+{{- $path := ($.Path) -}}
+{{ $pathFormatted := replace $path "\\" "/" }}
+{{- $prefix := index (split $path "/") 0 -}}
+{{- $github := index ($.Site.Param "github") $prefix -}}
+{{ if not $github }}{{- $github = ($.Site.Param "github") -}}{{ end }}
+{{ if $github }}
+{{ $gh_repo := index $github "repo" }}
 {{ if isset .Params "lastmod" }}
-{{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
+{{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $gh_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
+{{ end }}
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Since the content in our website is generated from multiple repositories, the github URLs for things like viewing the last commit for a page, or editing a page, all need to calculate the proper github URL based on the current page's path.

This fixes the calculation for the last commit for a page, which is displayed at the bottom of the page.
