### PR TITLE
SIG -> TAG text updates in various MD files

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,5 +1,5 @@
 ---
-title: CNCF SIG Contributor Strategy Charter
+title: CNCF TAG Contributor Strategy Charter
 linkTitle: Charter
 ---
 
@@ -20,8 +20,8 @@ Reviewed and/or contributed to by:
 * Sarah Allen
 
 ## Introduction
-This charter describes the operations of the CNCF Special Interest Group (SIG)
-Contributor Strategy. This SIG is responsible for contributor experience,
+This charter describes the operations of the CNCF Technical Advisory Group (TAG)
+Contributor Strategy. This TAG is responsible for contributor experience,
 sustainability, governance, and openness guidance to help CNCF community groups
 and projects with their own contributor strategies for a healthy project.
 
@@ -31,7 +31,7 @@ Our initial three stakeholders:
 3 - TOC
 
 ## Mission
-Consistent with the CNCF SIG definition, the mission of CNCF SIG Contributor
+Consistent with the CNCF TAG definition, the mission of CNCF TAG Contributor
 Strategy is to collaborate on strategies related to building, scaling, and
 retaining contributor communities, including (people) governance, 
 communications, operations, and tools. We want to help grow flourishing, 
@@ -52,7 +52,7 @@ points for rolling feedback and guidance.
 
 #### In scope:
 The following, non exhaustive list of activities and deliverables are
-in-scope for the SIG:
+in-scope for the TAG:
 * Definition of a contributor. This is helpful across projects for metrics and
 establishing guidelines, programs, and workflows.
 * Contributor and goverance related proposed/suggested/modified project 
@@ -68,9 +68,9 @@ via surveys, GB reps, and Maintainers Circle (Example: what is the project doing
   now, challenges, gaps)
 
 #### Out of scope
-* The day to day operations of CNCF SIGs, Kubernetes SIGs, or any community 
+* The day to day operations of CNCF TAGs, Kubernetes SIGs, or any community 
 group of CNCF or its respective projects of any graduation level.
-* The creation and approval of CNCF SIGs or other community groups; we will
+* The creation and approval of CNCF TAGs or other community groups; we will
 offer advice but the responsibility lies on the TOC for those matters.
 * CNCF operations and marketing initiatives such as: product review/demo
 webinars, kubecon event planning, branding, stickers, swag, etc
@@ -96,12 +96,12 @@ If you see something here that interests you, join us and start it:
 * Automation and self service for contributors, community GitOps
 
 ## Governance
-This SIGs topic requires cross collaboration between end users, CNCF SIGs, and
+This TAGs topic requires cross collaboration between end users, CNCF TAGs, and
 CNCF projects of all graduation levels.
 
-This SIG should be populated and governed by reps from CNCF projects that want
+This TAG should be populated and governed by reps from CNCF projects that want
 to create and run intentional contributor experience programs, a rep(s) from the
-end user committee, and the TOC liaison(s). While the SIG reps do not need to be
+end user committee, and the TOC liaison(s). While the TAG reps do not need to be
 core maintainers, they do need to have a drive for making things better for
 contributors and end users. We welcome industry experts and academics in
 relevant working groups!
@@ -114,24 +114,24 @@ during a public TOC meeting.
 
 ### Members
 
-Members are active participants in the work of the SIG who are entitled to vote
-in any SIG decisions that require a vote.  Any contributor to the SIG is
-eligible to become a member after participating in the work of the SIG for at
+Members are active participants in the work of the TAG who are entitled to vote
+in any TAG decisions that require a vote.  Any contributor to the TAG is
+eligible to become a member after participating in the work of the TAG for at
 least three months.
 
-In order to prevent the SIG from becoming unbalanced, it will have the following
+In order to prevent the TAG from becoming unbalanced, it will have the following
 limits on who can be a voting member:
 
 Up to one from each participating Incubating or Sandbox CNCF project
 Up to two from each Graduated CNCF project
-One from each SIG-ContribStrat Working Group, generally the lead for that WG
+One from each TAG-ContribStrat Working Group, generally the lead for that WG
 No more than ⅓ of members from the same employer
 
 If a contributor would be entitled to be a member, but are restricted because of
 the above limits, they are a non-voting member who may participate in meetings
 but cannot vote.
 
-Members who are no longer participating actively in the SIG (including both WG
+Members who are no longer participating actively in the TAG (including both WG
   work and the regular meetings) will step down from membership.
 
 #### Chairs and TOC Liaison
@@ -142,14 +142,14 @@ Dillon)
 - Tech Leads: None at this time but can change with need at a later time with
 charter ratification   
 
-In accordance with the terms and roles laid out in [cncf-sigs.md](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md)
+In accordance with the terms and roles laid out in [cncf-tags.md](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md)
 
-The TOC will also appoint 3 [Chairs](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#chair)
+The TOC will also appoint 3 [Chairs](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#chair)
 
 ### Meetings and Decisions
 
-Most SIG work will be carried out without requiring any kind of regular meeting
-or vote. The SIG will have a regular meeting, bi-weekly, at which the
+Most TAG work will be carried out without requiring any kind of regular meeting
+or vote. The TAG will have a regular meeting, bi-weekly, at which the
 membership may vote on the following items as the come up:
 
 * Addition of new members or removal of inactive ones
@@ -161,17 +161,17 @@ the TOC
 
 ### Bootstrapping
 
-Initially, the TOC shall appoint three members in order to launch the SIG
+Initially, the TOC shall appoint three members in order to launch the TAG
 
 ## Reach out!
-Mailing List: [sig-contributor-strategy](mailto:sig-contributor-strategy@lists.cncf.io)
+Mailing List: [tag-contributor-strategy](mailto:tag-contributor-strategy@lists.cncf.io)
 mailer at [lists.cncf.io](https://lists.cncf.io)  
 [Meeting Notes](https://docs.google.com/document/d/1Xjw-yAqidQW67zv7OfMRErsfCotc-mfQ_248Te_YL0g/edit#heading=h.252i9x89qe0d)  
-Slack channel: [#sig-contributor-strategy]  
+Slack channel: [#tag-contributor-strategy]  
 Public Meetings: Bi-weekly on Thursday at 5:30pm UTC. Join our mailing list for
 
 
-[cncf-sigs.md]: https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md
-[sig-contributor-strategy]: mailto:sig-contributor-strategy@lists.cncf.io
+[cncf-tags.md]: https://github.com/cncf/toc/blob/main/tags/cncf-tags.md
+[tag-contributor-strategy]: mailto:tag-contributor-strategy@lists.cncf.io
 [lists.cncf.io]: https://lists.cncf.io
 [Meeting Notes]: https://docs.google.com/document/d/1Xjw-yAqidQW67zv7OfMRErsfCotc-mfQ_248Te_YL0g/edit#heading=h.252i9x89qe0d

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributor Strategy Special Interest Group Contributing Guide
+# Contributor Strategy Technical Advisory Group Contributing Guide
 *this is a bootstrapped document that will update frequently in the next few
-months as we lay the groundwork for the operations of the SIG. Now onto the
+months as we lay the groundwork for the operations of the TAG. Now onto the
 show...:*
 
 🛬Thanks for landing here! There's a good chance you want to help the
@@ -8,11 +8,11 @@ contributor side of the code in one of our working groups, get involved on a
 regular basis, or simply be curious, no matter your reason, we are excited to have
 you.
 
-This [SIG] (Special Interest Group) is an extension of the [TOC] that works to
+This [TAG] (Technical Advisory Group) is an extension of the [TOC] that works to
 build programs and guidance to help scale and grow open source communities. We
 work in two CNCF GitHub repositories:  
 
-🆕[cncf/sig-contributor-strategy]  
+🆕[cncf/tag-contributor-strategy]  
  contains our meta docs that cover our governance, how we operate, and resources that we
  collect along the way. The [website/content] directory contains the source for the
  web pages at [contribute.cncf.io/maintainers][maintainers] and is advice for people who
@@ -61,7 +61,7 @@ an operational level
 - Give us feedback on where you need help, guidance, requested templates,
 recommendations, and more here
   - Or you can provide feedback by filing issues against the
-cncf/sig-contributor-strategy repo, send a note to the mailing list, or find a
+cncf/tag-contributor-strategy repo, send a note to the mailing list, or find a
 chair or working group facilitator privately on slack.
 - Become a contributor in one of our [working groups]
   - File issues and PRs
@@ -120,13 +120,13 @@ https://www.firsttimersonly.com/
 [CNCF’s code of conduct]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
 [communication channels]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md#communications
 [TOC]: https://www.cncf.io/people/technical-oversight-committee/
-[SIG]: https://github.com/cncf/toc/tree/master/sigs
+[TAG]: https://github.com/cncf/toc/tree/main/tags
 [README]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md
 [charter]: https://github.com/cncf/tag-contributor-strategy/blob/main/CHARTER.md
 [working groups]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md#working-groups
 [cncf/contribute]: https://github.com/cncf/contribute
-[cncf/sig-contributor-strategy]: https://github.com/cncf/sig-contributor-strategy
-[maintainers circle]: https://github.com/cncf/sig-contributor-strategy/issues/1
+[cncf/tag-contributor-strategy]: https://github.com/cncf/tag-contributor-strategy
+[maintainers circle]: https://github.com/cncf/tag-contributor-strategy/issues/1
 [4th Thursday meeting of each month]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md#meetings
 [website/content]: website/content/
 [contributing guide]: https://cncf-contribute.netlify.app/about/contributing/

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# CNCF SIG Contributor Strategy
+# CNCF TAG Contributor Strategy
 
-SIG Contributor Strategy is responsible for contributor experience,
+TAG Contributor Strategy is responsible for contributor experience,
 sustainability, governance, and openness guidance to help CNCF community groups
 and projects with their own contributor strategies for a healthy project.
 
-The [SIG Contributor Strategy charter](/CHARTER.md) outlines the scope of our group activities. To get involved, our [Contributing Guide](/CONTRIBUTING.md) lays out more details.
+The [TAG Contributor Strategy charter](/CHARTER.md) outlines the scope of our group activities. To get involved, our [Contributing Guide](/CONTRIBUTING.md) lays out more details.
 
 - [Meetings](#meetings)
 - [Communicating With Us](#communicating-with-us)
 - [Members](#members)
-  - [SIG Chairs](#sig-chairs)
+  - [TAG Chairs](#tag-chairs)
   - [TOC Liaisons](#toc-liaisons)
-  - [Bootstrap SIG members](#bootstrap-sig-members)
+  - [Bootstrap TAG members](#bootstrap-tag-members)
 - [Working Groups](#working-groups)
   - [Governance](#governance)
   - [Contributor Growth](#contributor-growth)
@@ -20,14 +20,14 @@ The [SIG Contributor Strategy charter](/CHARTER.md) outlines the scope of our gr
 
 ## Meetings
 
-The Contributor Strategy Special Interest Group meets biweekly on Thursday at
+The Contributor Strategy Teechnical Advisory Group meets biweekly on Thursday at
 10:30am PT (USA Pacific, see your timezone [here](https://time.is/compare/1030AM_26_Mar_2020_in_PT)):
 
 - Calendar invites are sent to the mailing list(see: [Communicating with us](#communicating-with-us)).
 Once you join, you won't automatically have the invite on your calendar. You can
-get it from a [past message here](https://lists.cncf.io/g/cncf-sig-contributor-strategy/message/1)
+get it from a [past message here](https://lists.cncf.io/g/cncf-tag-contributor-strategy/message/1)
 - [Meeting minutes and agenda](https://bit.ly/cncf-contribstrat-agenda)
-- Meeting Link: [zoom.us/my/cncfsigcontributorstrategy](https://zoom.us/my/cncfsigcontributorstrategy)
+- Meeting Link: [zoom.us/my/cncftagcontributorstrategy](https://zoom.us/my/cncftagcontributorstrategy)
   - Meeting ID: **574 406 1161**
   - One tap mobile:
     - +16465588656,,5744061161# US (New York)
@@ -50,29 +50,29 @@ get it from a [past message here](https://lists.cncf.io/g/cncf-sig-contributor-s
 
 ## Communicating with Us
 
-Anyone is welcome to join our open discussions of SIG Contributor Strategy
+Anyone is welcome to join our open discussions of TAG Contributor Strategy
 projects and share news related to the group's mission and charter. Much of the
-work of the group happens outside of SIG Contributor Strategy meetings and we
+work of the group happens outside of TAG Contributor Strategy meetings and we
 encourage project teams to share progress updates or post questions in these
 channels:
 
-- [Mailing list](https://lists.cncf.io/g/cncf-sig-contributor-strategy)
+- [Mailing list](https://lists.cncf.io/g/cncf-tag-contributor-strategy)
   - The mailing list is used for decisions, announcements, and broad communications
-  on record for the entire SIG.
+  on record for the entire TAG.
   - Calendar invites will be sent to this address. You can get the calendar
-  invite from a [past message here](https://lists.cncf.io/g/cncf-sig-contributor-strategy/message/2)
+  invite from a [past message here](https://lists.cncf.io/g/cncf-tag-contributor-strategy/message/2)
 
-- [#sig-contributor-strategy](https://cloud-native.slack.com/archives/CT6CWS1JN) on [CNCF Slack](https://slack.cncf.io/)
+- [#tag-contributor-strategy](https://cloud-native.slack.com/archives/CT6CWS1JN) on [CNCF Slack](https://slack.cncf.io/)
   - Real time communication is great! Chat with us here but we might ask you to
   open an issue or remind us on the mailing list so we can have a record.
 
-- [File an Issue](https://github.com/cncf/sig-contributor-strategy)
+- [File an Issue](https://github.com/cncf/tag-contributor-strategy)
   - Working on a project? Have an idea for something we/you should work on? Talk
   about a change you'd like to propose?
 
 ## Members
 
-### SIG Chairs
+### TAG Chairs
 
 - Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple
 - Josh Berkus ([@jberkus](https://github.com/jberkus)), Red Hat
@@ -87,7 +87,7 @@ channels:
 - Saad Ali ([@saad-ali](https://github.com/saad-ali)), Google
 - Alena Prokharchyk ([@alena1108](https://github.com/alena1108)), Apple
 
-### Bootstrap SIG members
+### Bootstrap TAG members
 
 - Amye Scavarda Perrin ([@amye](https://github.com/amye)), CNCF
 - April Kyle Nassi ([@thisisnotapril](https://github.com/thisisnotapril)), Google
@@ -126,7 +126,7 @@ Facilitators:
 
 ### Maintainer's Circle
 
-Status: [Proposed](https://github.com/cncf/sig-contributor-strategy/issues/1)
+Status: [Proposed](https://github.com/cncf/tag-contributor-strategy/issues/1)
 
 Facilitators:
 
@@ -136,7 +136,7 @@ Facilitators:
 
 ### GitHub Management
 
-Status: [Proposed](https://github.com/cncf/sig-contributor-strategy/issues/5)
+Status: [Proposed](https://github.com/cncf/tag-contributor-strategy/issues/5)
 
 Facilitators:
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,4 +1,4 @@
 # Code of Conduct 
 
-The SIG Contributor Strategy follows the 
+The TAG Contributor Strategy follows the 
 [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -57,9 +57,9 @@ Don't see your name? That was an oversight! Open a PR and add yourself. ❤️
 
 Meetings take place every 1st and 3rd Tuesday at 2pm PT / 4pm CT Tuesdays.
 
-Discussion happens on the [mailing list] or on #sig-contributor-strategy on [Slack].
+Discussion happens on the [mailing list] or on #tag-contributor-strategy on [Slack].
 
-[mailing list]: https://lists.cncf.io/g/cncf-sig-contributor-strategy
+[mailing list]: https://lists.cncf.io/g/cncf-tag-contributor-strategy
 [Slack]: https://slack.cncf.io/
 
 # Documentation

--- a/governance/README.md
+++ b/governance/README.md
@@ -1,8 +1,8 @@
 # Governance
 
-The Governance working group of Contributor Strategy aims to assist all CNCF projects with implementing good open source governance practices.  If you are looking for the governance documents of SIG-Contributor-Strategy itself, please read CONTRIBUTING.md.
+The Governance working group of Contributor Strategy aims to assist all CNCF projects with implementing good open source governance practices.  If you are looking for the governance documents of TAG-Contributor-Strategy itself, please read CONTRIBUTING.md.
 
-If you are interested in helping with this project, please speak up on #sig-contributor-strategy in CNCF Slack, or on the mailing list.
+If you are interested in helping with this project, please speak up on #tag-contributor-strategy in CNCF Slack, or on the mailing list.
 
 ## Goals of the Working Group
 
@@ -12,7 +12,7 @@ If you are interested in helping with this project, please speak up on #sig-cont
 
 ## Scope
 
-The Governance working group is focused on, and restricted to, matters related to CNCF project governance, defined as project participation roles, rules, and procedures.  For more information on what governance is, please see the [Governance Documentation](https://github.com/cncf/sig-contributor-strategy/tree/master/governance/docs). As examples, this would include issues like:
+The Governance working group is focused on, and restricted to, matters related to CNCF project governance, defined as project participation roles, rules, and procedures.  For more information on what governance is, please see the [Governance Documentation](https://contribute.cncf.io/maintainers/governance/). As examples, this would include issues like:
 
 * Selection/election process for new Owners
 * How to make sure your meetings are really open
@@ -25,7 +25,7 @@ The Governance working group is focused on, and restricted to, matters related t
 The following are examples of things outside of the scope of this working group:
 
 * Recruiting new contributors (this will be handled by Contributor Growth working group)
-* CNCF SIG governance (handled by the TOC)
+* CNCF TAG governance (handled by the TOC)
 * Drafting legal documents for your project, or choosing a license (we're not attorneys)
 
 ## Working Group Members
@@ -42,7 +42,7 @@ The following contributors are currently "members" of this working group:
 
 Meetings take place every 1st and 3rd Tuesday at 10am PT.
 
-Discussion happens on the [contributor strategy mailing list](https://lists.cncf.io/g/cncf-sig-contributor-strategy) or on #sig-contributor-strategy on [CNCF slack](https://slack.cncf.io/).
+Discussion happens on the [contributor strategy mailing list](https://lists.cncf.io/g/cncf-tag-contributor-strategy) or on #tag-contributor-strategy on [CNCF slack](https://slack.cncf.io/).
 
 ## Directory
 

--- a/resources.md
+++ b/resources.md
@@ -1,7 +1,7 @@
 # Useful resources, research, and quick links
 
 ## Purpose  
-Serve as a quick resource for the SIG to grab links that we work with at high frequency and reference from other research. This is not official guidance.
+Serve as a quick resource for the TAG to grab links that we work with at high frequency and reference from other research. This is not official guidance.
 
 ### CNCF Quick Links
 


### PR DESCRIPTION
fixed a bunch of instances where we were still referring to the SIG, instead of the TAG.