### PR TITLE
Update docs to use TAG instead of SIG

### DIFF
--- a/website/content/about/_index.html
+++ b/website/content/about/_index.html
@@ -1,5 +1,5 @@
 ---
-title: About SIG Contributor Strategy
+title: About TAG Contributor Strategy
 linkTitle: About
 type: single
 layout: single
@@ -10,14 +10,14 @@ menu:
 ---
 
 
-{{< blocks/cover title="About SIG Contributor Strategy" image_anchor="bottom" height="min" >}}
+{{< blocks/cover title="About TAG Contributor Strategy" image_anchor="bottom" height="min" >}}
 
 
 {{< /blocks/cover >}}
 
 {{% blocks/lead color="primary" %}}
 
-SIG Contributor Strategy is responsible for contributor experience,
+TAG Contributor Strategy is responsible for contributor experience,
 sustainability, governance, and openness guidance to help CNCF community groups
 and projects with their own contributor strategies for a healthy project.
     
@@ -33,7 +33,7 @@ with smooth journeys throughout their CNCF project lifecycle.
 
 <div class="section-group">
   {{% blocks/lead color="dark" %}}
-  The mission of CNCF SIG Contributor Strategy is to collaborate on strategies
+  The mission of CNCF TAG Contributor Strategy is to collaborate on strategies
   related to building, scaling, and retaining contributor communities, including
   (people) governance, communications, operations, and tools. We want to help grow
   flourishing, sustainable communities with smooth journeys throughout their CNCF
@@ -100,17 +100,17 @@ We meet every 2nd and 3rd Thursday at 10:30am PT (USA Pacific, see your timezone
 
 - Calendar invites are sent to the [mailing list]. Once you join, you won't
 automatically have the invite on your calendar. You can get it from a [past
-message here](https://lists.cncf.io/g/cncf-sig-contributor-strategy/message/1)
+message here](https://lists.cncf.io/g/cncf-tag-contributor-strategy/message/1)
 - [Meeting minutes and agenda](https://bit.ly/cncf-contribstrat-agenda)
-- Meeting Link: [zoom.us/my/cncfsigcontributorstrategy](https://zoom.us/my/cncfsigcontributorstrategy)
+- Meeting Link: [zoom.us/my/cncftagcontributorstrategy](https://zoom.us/my/cncftagcontributorstrategy)
 
 </div>
 
-[mailing list]: https://lists.cncf.io/g/cncf-sig-contributor-strategy
+[mailing list]: https://lists.cncf.io/g/cncf-tag-contributor-strategy
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fas fa-envelope" title="Mailing List"
-url="https://lists.cncf.io/g/cncf-sig-contributor-strategy" url_text="Sign Up" %}}
+url="https://lists.cncf.io/g/cncf-tag-contributor-strategy" url_text="Sign Up" %}}
 Keep up-to-date on new templates, advisory guides, and what we are planning next.
 {{% /blocks/feature %}}
 

--- a/website/content/about/contributing.md
+++ b/website/content/about/contributing.md
@@ -45,8 +45,7 @@ Targets:
 
 ## Content Organization
 
-The main website and the "Maintainers" section is in the [TAG
-Contributor Strategy repository]. 
+The main website and the "Maintainers" section is in the [TAG Contributor Strategy repository]. 
 
 1. Clone the [TAG Contributor Strategy repository].
 1. Follow the steps to [Preview your changes locally](#preview-your-changes-locally).

--- a/website/content/about/contributing.md
+++ b/website/content/about/contributing.md
@@ -45,17 +45,17 @@ Targets:
 
 ## Content Organization
 
-The main website and the "Maintainers" section is in the [SIG
+The main website and the "Maintainers" section is in the [TAG
 Contributor Strategy repository]. 
 
-1. Clone the [SIG Contributor Strategy repository].
+1. Clone the [TAG Contributor Strategy repository].
 1. Follow the steps to [Preview your changes locally](#preview-your-changes-locally).
 1. Optionally clone the [cncf/contribute repository] in a directory
-    next to the SIG Contributor Strategy repository to edit content
+    next to the TAG Contributor Strategy repository to edit content
     in the "Contributors" section.
     
     For example, if you have cloned the Contributor Strategy repo to 
-    `~/src/sig-contributor-strategy`, clone the CNCF Contribute repo to
+    `~/src/tag-contributor-strategy`, clone the CNCF Contribute repo to
     `~/src/contribute`.
 
 If you need to clone the CNCF Contribute repository elsewhere, set an environment
@@ -68,7 +68,7 @@ Here's a quick guide to updating the docs. It assumes you're familiar with the
 GitHub workflow, and you're happy to use the automated preview of your doc
 updates:
 
-1. Fork the [SIG Contributor Strategy repository] on GitHub.
+1. Fork the [TAG Contributor Strategy repository] on GitHub.
 1. Make your changes and send a pull request (PR).
 1. If you're not yet ready for a review, add "WIP" to the PR name or create a
    Draft Pull Request to indicate it's a work in progress.
@@ -108,7 +108,7 @@ Docsy has a shortcut for you:
 If you want to run a Docker container to preview your changes as you work:
 
 1. [Install Docker](https://docs.docker.com/get-docker/) and [Go].
-1. Fork the [SIG Contributor Strategy repository] into your own project, then
+1. Fork the [TAG Contributor Strategy repository] into your own project, then
    create a local copy using `git clone`. 
 1. Run `mage preview` to preview the site. When the site is ready, it will open
    your web browser to http://localhost:1313/. Now that you're serving your site
@@ -122,7 +122,7 @@ If you need to see the Hugo output, run `mage logs`.
 ## Creating an issue
 
 If you've found a problem in the docs, but you're not sure how to fix it
-yourself, please create an issue in the [SIG Contributor Strategy repository].
+yourself, please create an issue in the [TAG Contributor Strategy repository].
 You can also create an issue about a specific page by clicking the **Create
 Issue** button in the top right hand corner of the page.
 
@@ -136,5 +136,5 @@ Issue** button in the top right hand corner of the page.
 * [Github Hello World!](https://guides.github.com/activities/hello-world/): A
   basic introduction to GitHub concepts and workflow.
 
-[SIG Contributor Strategy repository]: https://github.com/cncf/sig-contributor-strategy
+[TAG Contributor Strategy repository]: https://github.com/cncf/tag-contributor-strategy
 [cncf/contribute repository]: https://github.com/cncf/contribute

--- a/website/content/about/working-groups/contributor-growth.html
+++ b/website/content/about/working-groups/contributor-growth.html
@@ -20,12 +20,12 @@ contributor base.
 
 Meetings take place every 1st and 3rd Tuesday at 2pm PT. (USA Pacific, see your timezone [here](https://time.is/compare/200PM_in_PT)):
 
-* [Zoom](https://zoom.us/my/cncfsigcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09) passcode: `77777`
+* [Zoom](https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09) passcode: `77777`
 * [Meeting Minutes and Agenda](https://docs.google.com/document/d/1Kx7tZv5wTXQ7uRKxn5d9d2wLsI3Q3Q51A0i06nLvtdI/edit)
 
-Discussion happens on the [mailing list] or on #sig-contributor-strategy on [Slack].
+Discussion happens on the [mailing list] or on #tag-contributor-strategy on [Slack].
 
-[mailing list]: https://lists.cncf.io/g/cncf-sig-contributor-strategy
+[mailing list]: https://lists.cncf.io/g/cncf-tag-contributor-strategy
 [Slack]: https://slack.cncf.io/
 
 {{% /blocks/section %}}

--- a/website/content/about/working-groups/governance.html
+++ b/website/content/about/working-groups/governance.html
@@ -20,12 +20,12 @@ practices.
 
 Meetings take place every 1st and 3rd Tuesday at 2pm PT. (USA Pacific, see your timezone [here](https://time.is/compare/1030AM_in_PT)):
 
-* [Zoom](https://zoom.us/my/cncfsigcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09) passcode: `77777`
+* [Zoom](https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09) passcode: `77777`
 * [Meeting Minutes and Agenda](https://docs.google.com/document/d/1P9tQgCM6OwDHd1F8UnWuauL4KDVTMTp49_n64_w8nrs/edit)
 
-Discussion happens on the [mailing list] or on #sig-contributor-strategy on [Slack].
+Discussion happens on the [mailing list] or on #tag-contributor-strategy on [Slack].
 
-[mailing list]: https://lists.cncf.io/g/cncf-sig-contributor-strategy
+[mailing list]: https://lists.cncf.io/g/cncf-tag-contributor-strategy
 [Slack]: https://slack.cncf.io/
 
 {{% /blocks/section %}}

--- a/website/content/about/working-groups/maintainers-circle.html
+++ b/website/content/about/working-groups/maintainers-circle.html
@@ -81,7 +81,7 @@ Thursdays, 10:30am PT / 06:30pm GMT / [Your timezone here](https://time.is/compa
 
 See the [CNCF calendar](https://www.cncf.io/calendar/).
 
-*currently displays as sig-contributor-strategy meeting on [CNCF calendar](https://www.cncf.io/calendar/) but will be repurposed for this.
+*currently displays as tag-contributor-strategy meeting on [CNCF calendar](https://www.cncf.io/calendar/) but will be repurposed for this.
 </div>
 {{% /blocks/feature %}}
 
@@ -138,7 +138,7 @@ into final small groups of the session.
 
 To suggest future topics, file an issue in our repo. If you have something to
 share with the group, reach out to us on slack directly
-[#sig-contributor-strategy](https://cloud-native.slack.com/archives/CT6CWS1JN).
+[#tag-contributor-strategy](https://cloud-native.slack.com/archives/CT6CWS1JN).
 
 </div>
 {{% /blocks/section %}}


### PR DESCRIPTION
Hello everyone

This PR fixes some occurrences of SIG and replaces them with TAG. Furthermore, it fixes some links that use SIG and point to a 404 - after the update they work again, e.g. the mailing list.

Best regards
Marc