### PR TITLE
Do not hard code meeting times

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -168,7 +168,7 @@ Mailing List: [tag-contributor-strategy](mailto:tag-contributor-strategy@lists.c
 mailer at [lists.cncf.io](https://lists.cncf.io)  
 [Meeting Notes](https://docs.google.com/document/d/1Xjw-yAqidQW67zv7OfMRErsfCotc-mfQ_248Te_YL0g/edit#heading=h.252i9x89qe0d)  
 Slack channel: [#tag-contributor-strategy]  
-Public Meetings: Bi-weekly on Thursday at 5:30pm UTC. Join our mailing list for
+Public Meetings: Go to https://www.cncf.io/calendar/ and enter "TAG Contributor Strategy" in the search box to see our meetings
 
 
 [cncf-tags.md]: https://github.com/cncf/toc/blob/main/tags/cncf-tags.md

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -168,7 +168,7 @@ Mailing List: [tag-contributor-strategy](mailto:tag-contributor-strategy@lists.c
 mailer at [lists.cncf.io](https://lists.cncf.io)  
 [Meeting Notes](https://docs.google.com/document/d/1Xjw-yAqidQW67zv7OfMRErsfCotc-mfQ_248Te_YL0g/edit#heading=h.252i9x89qe0d)  
 Slack channel: [#tag-contributor-strategy]  
-Public Meetings: Go to https://www.cncf.io/calendar/ and enter "TAG Contributor Strategy" in the search box to see our meetings
+Public Meetings: Go to [the CNCF calendar](https://www.cncf.io/calendar/) and enter "TAG Contributor Strategy" in the search box to see our meetings
 
 
 [cncf-tags.md]: https://github.com/cncf/toc/blob/main/tags/cncf-tags.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ resources and advice.
   - Take back this information to build (or continue to build!) intentional
 community and governance spaces and/or roles in your project to do this work at
 an operational level
-- Join us for a Contributor Strategy AMA on the [4th Thursday meeting of each month]. This is your time to ask us general or
+- Have questions? Drop in on a [meeting], either the main TAG meeting or the relevant working group meeting. This is your time to ask us general or
  specific questions that can give you ideas, unblock you, or help with strategy around TOC graduation or incubation project criteria.
 - Give us feedback on where you need help, guidance, requested templates,
 recommendations, and more here
@@ -127,8 +127,8 @@ https://www.firsttimersonly.com/
 [cncf/contribute]: https://github.com/cncf/contribute
 [cncf/tag-contributor-strategy]: https://github.com/cncf/tag-contributor-strategy
 [maintainers circle]: https://github.com/cncf/tag-contributor-strategy/issues/1
-[4th Thursday meeting of each month]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md#meetings
 [website/content]: website/content/
 [contributing guide]: https://cncf-contribute.netlify.app/about/contributing/
 [maintainers]: https://cncf-contribute.netlify.app/maintainers
 [contributors]: https://cncf-contribute.netlify.app/contributors 
+[meeting]: https://github.com/cncf/tag-contributor-strategy/#meetings

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The [TAG Contributor Strategy charter](/CHARTER.md) outlines the scope of our gr
 
 ## Meetings
 
-The Contributor Strategy Teechnical Advisory Group meets biweekly on Thursday at
-10:30am PT (USA Pacific, see your timezone [here](https://time.is/compare/1030AM_26_Mar_2020_in_PT)):
+We have one general meeting a month, along with meetings for our working groups.
+Go to https://www.cncf.io/calendar/ and enter "TAG Contributor Strategy" in the search box to see when we meet next.
 
 - Calendar invites are sent to the mailing list(see: [Communicating with us](#communicating-with-us)).
 Once you join, you won't automatically have the invite on your calendar. You can

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The [TAG Contributor Strategy charter](/CHARTER.md) outlines the scope of our gr
 ## Meetings
 
 We have one general meeting a month, along with meetings for our working groups.
-Go to https://www.cncf.io/calendar/ and enter "TAG Contributor Strategy" in the search box to see when we meet next.
+Go to [the CNCF calendar](https://www.cncf.io/calendar/) and enter "TAG Contributor Strategy" in the search box to see when we meet next.
 
 - Calendar invites are sent to the mailing list(see: [Communicating with us](#communicating-with-us)).
 Once you join, you won't automatically have the invite on your calendar. You can

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -55,7 +55,8 @@ Don't see your name? That was an oversight! Open a PR and add yourself. ❤️
 
 ## Meetings
 
-Meetings take place every 1st and 3rd Tuesday at 2pm PT / 4pm CT Tuesdays.
+We meet twice a month.
+Go to https://www.cncf.io/calendar/ and enter "Contributor Growth WG" in the search box to see when we meet next.
 
 Discussion happens on the [mailing list] or on #tag-contributor-strategy on [Slack].
 

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -56,7 +56,7 @@ Don't see your name? That was an oversight! Open a PR and add yourself. ❤️
 ## Meetings
 
 We meet twice a month.
-Go to https://www.cncf.io/calendar/ and enter "Contributor Growth WG" in the search box to see when we meet next.
+Go to [the CNCF calendar](https://www.cncf.io/calendar/) and enter "Contributor Growth WG" in the search box to see when we meet next.
 
 Discussion happens on the [mailing list] or on #tag-contributor-strategy on [Slack].
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -41,7 +41,7 @@ The following contributors are currently "members" of this working group:
 ## Meetings
 
 We meet twice a month.
-Go to https://www.cncf.io/calendar/ and enter "Governance WG" in the search box to see when we meet next.
+Go to [the CNCF calendar](https://www.cncf.io/calendar/) and enter "Governance WG" in the search box to see when we meet next.
 
 Discussion happens on the [contributor strategy mailing list](https://lists.cncf.io/g/cncf-tag-contributor-strategy) or on #tag-contributor-strategy on [CNCF slack](https://slack.cncf.io/).
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -40,7 +40,8 @@ The following contributors are currently "members" of this working group:
 
 ## Meetings
 
-Meetings take place every 1st and 3rd Tuesday at 10am PT.
+We meet twice a month.
+Go to https://www.cncf.io/calendar/ and enter "Governance WG" in the search box to see when we meet next.
 
 Discussion happens on the [contributor strategy mailing list](https://lists.cncf.io/g/cncf-tag-contributor-strategy) or on #tag-contributor-strategy on [CNCF slack](https://slack.cncf.io/).
 

--- a/maintainers-circle/README.md
+++ b/maintainers-circle/README.md
@@ -46,13 +46,12 @@ Important note: CNCF has a pool of listed maintainers for each project that vote
  roles than this and the Circle welcomes all decision makers. 
 
 ## Where
-Zoom with breakout rooms  
-In-person as soon as we can at the next face-to-face KubeCon (TBD) 
+Zoom with breakout rooms
+In-person at KubeCon
 
 ## When  
-Every other Contributor Strategy meeting:*  
-Thursdays, 10:30am PT / 06:30pm GMT / [Your timezone here](https://time.is/compare/1030AM_17_Dec_2020_in_PT)  
-*[CNCF calendar] https://www.cncf.io/calendar/.  
+Meetings are scheduled ad-hoc when we have a topic and speaker.
+Join our <a href="https://lists.cncf.io/g/cncf-tag-contributor-strategy">mailing list</a> or our #maintainers-circle channel in the CNCF Slack to be notified of the next event.
 
 ## What  
 
@@ -78,7 +77,7 @@ Sarah and the K8s bootstrap governance team developed values (which might actual
 **Breakout**   
 Think of a decision in your community that took a lot of effort to wrap up. Looking at the whole story arc – What do you wish you’d known at the beginning? Did the path to this decision reveal anything about the community? Is there a principle or value which fits the community which if explicit could have made the decision easier.
 
-### Febraury 11th @ 10:30am PT / 6:30pm GMT ([Your timezone here]
+### February 11th @ 10:30am PT / 6:30pm GMT ([Your timezone here]
 (https://time.is/compare/1030AM_17_Dec_2020_in_PT))
   
 Accidental Evangelist with Jérôme Petazzoni 

--- a/website/content/about/_index.html
+++ b/website/content/about/_index.html
@@ -94,7 +94,9 @@ Connect with other maintainers, share best practices, commiserate and grow.
 
 {{< blocks/section color="light" >}}
 {{% blocks/feature icon="fas fa-video" title="Meetings" %}}
-We meet every 2nd and 3rd Thursday at 10:30am PT (USA Pacific, see your timezone [here](https://time.is/compare/1030AM_in_PT)):
+
+
+Go to https://www.cncf.io/calendar/ and enter "TAG Contributor Strategy" in the search box to see when we meet next.
 
 <div class="text-left">
 

--- a/website/content/about/working-groups/contributor-growth.html
+++ b/website/content/about/working-groups/contributor-growth.html
@@ -18,7 +18,8 @@ contributor base.
 
 <div class="content">
 
-Meetings take place every 1st and 3rd Tuesday at 2pm PT. (USA Pacific, see your timezone [here](https://time.is/compare/200PM_in_PT)):
+We meet twice a month.
+Go to <a href="https://www.cncf.io/calendar/">cncf.io/calendar</a> and enter "Contributor Growth WG" in the search box to see when we meet next.
 
 * [Zoom](https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09) passcode: `77777`
 * [Meeting Minutes and Agenda](https://docs.google.com/document/d/1Kx7tZv5wTXQ7uRKxn5d9d2wLsI3Q3Q51A0i06nLvtdI/edit)

--- a/website/content/about/working-groups/governance.html
+++ b/website/content/about/working-groups/governance.html
@@ -18,8 +18,9 @@ practices.
 
 <div class="content">
 
-Meetings take place every 1st and 3rd Tuesday at 2pm PT. (USA Pacific, see your timezone [here](https://time.is/compare/1030AM_in_PT)):
-
+We meet twice a month.
+Go to <a href="https://www.cncf.io/calendar/">cncf.io/calendar</a> and enter "Governance WG" in the search box to see when we meet next.
+    
 * [Zoom](https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09) passcode: `77777`
 * [Meeting Minutes and Agenda](https://docs.google.com/document/d/1P9tQgCM6OwDHd1F8UnWuauL4KDVTMTp49_n64_w8nrs/edit)
 

--- a/website/content/about/working-groups/maintainers-circle.html
+++ b/website/content/about/working-groups/maintainers-circle.html
@@ -74,14 +74,9 @@ roles than this and the Circle welcomes all decision makers.
 {{% blocks/feature title="Meetings" icon="fas fa-video" %}}
 
 <div class="text-left">
+    Meetings are scheduled ad-hoc when we have a topic and speaker.
+    Join the our <a href="https://lists.cncf.io/g/cncf-tag-contributor-strategy">mailing list</a> or our #maintainers-circle channel in the CNCF Slack to be notified of the next event.
 
-
-Every other Contributor Strategy meeting:*  
-Thursdays, 10:30am PT / 06:30pm GMT / [Your timezone here](https://time.is/compare/1030AM_17_Dec_2020_in_PT)  
-
-See the [CNCF calendar](https://www.cncf.io/calendar/).
-
-*currently displays as tag-contributor-strategy meeting on [CNCF calendar](https://www.cncf.io/calendar/) but will be repurposed for this.
 </div>
 {{% /blocks/feature %}}
 


### PR DESCRIPTION
We haven't been great at updating all the places where we hard code our meeting times. This has resulted in people missing meetings which is unfortunate.

I have updated our website to explain how to find our meetings and removed hard coded meeting times.

Fixes #138