### PR TITLE
Fix calendar link on about page

### DIFF
--- a/website/content/about/_index.html
+++ b/website/content/about/_index.html
@@ -96,7 +96,7 @@ Connect with other maintainers, share best practices, commiserate and grow.
 {{% blocks/feature icon="fas fa-video" title="Meetings" %}}
 
 
-Go to https://www.cncf.io/calendar/ and enter "TAG Contributor Strategy" in the search box to see when we meet next.
+Go to <a href="https://www.cncf.io/calendar/">cncf.io/calendar</a> and enter "TAG Contributor Strategy" in the search box to see when we meet next.
 
 <div class="text-left">
 


### PR DESCRIPTION
This fixes one last link to be consistent with how we link to the calendar on other website pages.