### PR TITLE
Add Burnout folder, with Julia Simon and mcgonagle as owners.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -58,6 +58,13 @@ collaborators:
 
   - username: iennae
     permission: push
+    
+    # burnout forum leads
+  - username: juliasimon
+    permission: push
+  
+  - username: mcgonagle
+    permission: push
 
 labels:
   - name: new-wg

--- a/maintainers-circle/burnout/README.md
+++ b/maintainers-circle/burnout/README.md
@@ -1,0 +1,5 @@
+# Burnout Forum
+
+This is the folder for the materials of the Burnout discussion group.
+
+Update me, please.


### PR DESCRIPTION
Creates a "burnout" folder under Maintainer Circle for the burnout discussion group.

Julia Simon and one other are added as repo contributors so that they can manage content in this folder.