### PR TITLE
TAG Contributor Strategy leadership updates

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -13,20 +13,17 @@ repository:
   # A URL with more information about the repository
   homepage: https://cncf.io/projects
 
-  # Collaborators: give specific users access to this repository.
-  # see /governance/roles.md for details on write access policy
-  # note that the permissions below may provide wider access than needed for
-  # a specific role, and we trust these individuals to act according to their
-  # role. If there are questions, please contact one of the chairs.
+# Collaborators: give specific users access to this repository.
+# see /governance/roles.md for details on write access policy
+# note that the permissions below may provide wider access than needed for
+# a specific role, and we trust these individuals to act according to their
+# role. If there are questions, please contact one of the chairs.
 collaborators:
-  # Chairs and Admin Help
-  - username: justaugustus
+  # Admins
+  - username: geekygirldawn
     permission: admin
 
   - username: jberkus
-    permission: admin
-
-  - username: parispittman
     permission: admin
 
   - username: idvoretskyi
@@ -35,9 +32,16 @@ collaborators:
   - username: carolynvs
     permission: admin
 
-    # Contributors
-    # all permissions except admin
-    
+  # Maintainers
+  - username: justaugustus
+    permission: maintain
+
+  - username: parispittman
+    permission: maintain
+
+  # Contributors
+  # all permissions except admin
+
   - username: gerred
     permission: push
 
@@ -53,16 +57,13 @@ collaborators:
   - username: dims
     permission: push
 
-  - username: geekygirldawn
-    permission: push
-
   - username: iennae
     permission: push
-    
-    # burnout forum leads
+
+  # burnout forum leads
   - username: juliasimon
     permission: push
-  
+
   - username: mcgonagle
     permission: push
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -134,13 +134,12 @@ but cannot vote.
 Members who are no longer participating actively in the TAG (including both WG
   work and the regular meetings) will step down from membership.
 
-#### Chairs and TOC Liaison
+#### Leadership
 
-- TOC Liaison: Matt Klein, Saad Ali   
-- Chairs: Josh Berkus, Stephen Augustus, Paris Pittman  (Emeritus: Gerred 
-Dillon)
-- Tech Leads: None at this time but can change with need at a later time with
-charter ratification   
+- [Chairs](/README.md#tag-chairs)
+- [Tech Leads](/README.md#tech-leads)
+- [TOC Liaisons](/README.md#toc-liaisons)
+- [Emeritus Leads](/README.md#emeritus-leads)
 
 In accordance with the terms and roles laid out in [cncf-tags.md](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md)
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ and projects with their own contributor strategies for a healthy project.
 The [TAG Contributor Strategy charter](/CHARTER.md) outlines the scope of our group activities. To get involved, our [Contributing Guide](/CONTRIBUTING.md) lays out more details.
 
 - [Meetings](#meetings)
-- [Communicating With Us](#communicating-with-us)
+- [Communicating with Us](#communicating-with-us)
 - [Members](#members)
   - [TAG Chairs](#tag-chairs)
+  - [Tech Leads](#tech-leads)
   - [TOC Liaisons](#toc-liaisons)
   - [Bootstrap TAG members](#bootstrap-tag-members)
+  - [Emeritus Leads](#emeritus-leads)
 - [Working Groups](#working-groups)
   - [Governance](#governance)
   - [Contributor Growth](#contributor-growth)
@@ -74,11 +76,10 @@ channels:
 
 ### TAG Chairs
 
-- Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple
+- Dawn Foster ([@geekygirldawn](https://github.com/geekygirldawn)), VMware
 - Josh Berkus ([@jberkus](https://github.com/jberkus)), Red Hat
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco
 
-### Tech Lead
+### Tech Leads
 
 - Carolyn Van Slyck ([@carolynvs](https://github.com/carolynvs)), Microsoft
 
@@ -93,15 +94,21 @@ channels:
 - April Kyle Nassi ([@thisisnotapril](https://github.com/thisisnotapril)), Google
 - Carolyn Van Slyck ([@carolynvs](https://github.com/carolynvs)), Microsoft
 - Cheryl Hung ([@oicheryl](https://github.com/oicheryl)), CNCF
-- Gerred Dillon ([@gerred](https://github.com/gerred)), D2iQ
+- Gerred Dillon ([@gerred](https://github.com/gerred)), Mycelial
 - Ihor Dvoretskyi ([@idvoretskyi](https://github.com/idvoretskyi)), CNCF
 - Josh Berkus ([@jberkus](https://github.com/jberkus)), Red Hat
 - Karen Chu ([@karenhchu](https://github.com/karenhchu)), Microsoft
 - Matt Klein ([@mattklein123](https://github.com/mattklein123)), Lyft
-- Paris Pittman ([@parispittman](https://github.com/parispittman)), Google
+- Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple
 - Saad Ali ([@saad-ali](https://github.com/saad-ali)), Google
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), VMware
+- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco
 - Zach Corleissen ([@zacharysarah](https://github.com/zacharysarah)), Linux Foundation
+
+### Emeritus Leads
+
+- Gerred Dillon ([@gerred](https://github.com/gerred)), Mycelial
+- Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple
+- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco
 
 ## Working Groups
 
@@ -115,14 +122,12 @@ Facilitators:
 
 ### Contributor Growth  
 
-
-* [Charter](/contributor-growth/README.md)
+[Charter](/contributor-growth/README.md)
 
 Facilitators:
 
 - Carolyn Van Slyck ([@carolynvs](https://github.com/carolynvs)), Microsoft
-- Paris Pittman ([@parispittman](https://github.com/parispittman)), Google
-
+- Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple
 
 ### Maintainer's Circle
 
@@ -130,8 +135,8 @@ Status: [Proposed](https://github.com/cncf/tag-contributor-strategy/issues/1)
 
 Facilitators:
 
-- Paris Pittman ([@parispittman](https://github.com/parispittman)), Google
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), VMware
+- Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple
+- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco
 - Zach Corleissen ([@zacharysarah](https://github.com/zacharysarah)), Linux Foundation
 
 ### GitHub Management
@@ -140,7 +145,7 @@ Status: [Proposed](https://github.com/cncf/tag-contributor-strategy/issues/5)
 
 Facilitators:
 
-- Gerred Dillon ([@gerred](https://github.com/gerred)), D2iQ
+- Gerred Dillon ([@gerred](https://github.com/gerred)), Mycelial
 - Ihor Dvoretskyi ([@idvoretskyi](https://github.com/idvoretskyi)), CNCF
 - Josh Berkus ([@jberkus](https://github.com/jberkus)), Red Hat
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), VMware
+- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco

--- a/website/content/about/_index.html
+++ b/website/content/about/_index.html
@@ -122,9 +122,8 @@ Keep up-to-date on new templates, advisory guides, and what we are planning next
 
 ## Leadership
 
-- Paris Pittman ([@parispittman](https://github.com/parispittman)), Google
+- Dawn Foster ([@geekygirldawn](https://github.com/geekygirldawn)), VMware
 - Josh Berkus ([@jberkus](https://github.com/jberkus)), Red Hat
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), VMware
 
 {{< /blocks/section >}}
 

--- a/website/content/maintainers/community/contributor-growth-framework/_index.md
+++ b/website/content/maintainers/community/contributor-growth-framework/_index.md
@@ -14,7 +14,7 @@ The first version of this document summarizes the experience different project m
 - [**Paris Pittman**](https://github.com/parispittman) (Kubernetes maintainer, Apple)
 - [**Carlisia Thompson**](https://github.com/carlisia) (Velero maintainer, VMware)
 - [**Aaron Schlesinger**](https://github.com/arschles) (KEDA-HTTP maintainer, Microsoft)
-- [**Stephen Augustus**](https://github.com/justaugustus) (Kubernetes maintainer, VMware)
+- [**Stephen Augustus**](https://github.com/justaugustus) (Kubernetes maintainer, Cisco)
 - [**Charles Pretzer**](https://github.com/cpretzer) (Linkerd maintainer, Buoyant)
 - [**Phil Estes**](https://github.com/estesp) (containerd maintainer, AWS)
 


### PR DESCRIPTION
Email to TAG ContribStrat: https://lists.cncf.io/g/cncf-tag-contributor-strategy/message/65

- TAG Contributor Strategy leadership updates
  - Add Dawn Foster (VMware) as TAG Chair
  - Emeritus Paris Pittman (Apple) and Stephen Augustus (Cisco)
- CHARTER.md: De-dupe leadership list with README.md

Also fixes affiliations in certain places.

Signed-off-by: Stephen Augustus <foo@auggie.dev>