### PR TITLE
Activate Google Analytics

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -96,7 +96,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-#id = "UA-00000000-0"
+id = "UA-140890431-3"
 
 # Language configuration
 


### PR DESCRIPTION
This activate Google Analytics for the Contribute site so we can measure traffic. I created a new property for the site in the CNCF Analytics account. I can provide access to the analytics to anyone who wants it.