### PR TITLE
Add TOC liaisons

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -60,6 +60,13 @@ collaborators:
   - username: iennae
     permission: push
 
+  # Current TOC liaisons
+  - username: mattfarina
+    permission: push
+  
+  - username: kgamanji
+    permission: push
+  
   # burnout forum leads
   - username: juliasimon
     permission: push


### PR DESCRIPTION
Add the TOC liaisons to the repository so that they can review pull requests and have their review "count" (green checkmark).
