### PR TITLE
Added the CNCF glossary to our resources page

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -13,6 +13,7 @@ Serve as a quick resource for the TAG to grab links that we work with at high fr
 - [Graduation Requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#graduation-stage)
 - [Sandbox->Incubation Requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)
 [Sandbox Annual Review has related questions](https://github.com/cncf/toc/blob/master/process/sandbox-annual-review.md#annual-review-contents)
+- [CNCF Glossary](https://glossary.cncf.io/)
 
 ### Governance
 - [Governance Checklist for OSS projects](https://sustainers.github.io/governance-readiness/)  


### PR DESCRIPTION
This is a tiny change to add the CNCF glossary to our resources, since I think people will find it useful.

cc: @jberkus @carolynvs 