### PR TITLE
Fix missing bullet point and links on resources page

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -12,7 +12,7 @@ Serve as a quick resource for the TAG to grab links that we work with at high fr
 - [Due Diligence Template](https://github.com/cncf/toc/blob/master/process/dd-review-template.md#project)
 - [Graduation Requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#graduation-stage)
 - [Sandbox->Incubation Requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)
-[Sandbox Annual Review has related questions](https://github.com/cncf/toc/blob/master/process/sandbox-annual-review.md#annual-review-contents)
+- [Sandbox Annual Review has related questions](https://github.com/cncf/toc/blob/master/process/sandbox-annual-review.md#annual-review-contents)
 - [CNCF Glossary](https://glossary.cncf.io/)
 
 ### Governance

--- a/resources.md
+++ b/resources.md
@@ -10,8 +10,8 @@ Serve as a quick resource for the TAG to grab links that we work with at high fr
   - [What type of goverance is my project expected to follow?](https://github.com/cncf/toc/blob/master/FAQ.md#what-type-of-governance-is-my-cncf-project-expected-to-follow)
 - [Due Diligence Guidelines](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md#project)
 - [Due Diligence Template](https://github.com/cncf/toc/blob/master/process/dd-review-template.md#project)
-- [Graduation Requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#graduation-stage)
-- [Sandbox->Incubation Requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)
+- [Graduation Requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#graduation-stage)
+- [Sandbox->Incubation Requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)
 - [Sandbox Annual Review has related questions](https://github.com/cncf/toc/blob/master/process/sandbox-annual-review.md#annual-review-contents)
 - [CNCF Glossary](https://glossary.cncf.io/)
 


### PR DESCRIPTION
One of the links in the resources was missing a bullet point and was being smooshed on the same line as the previous list item.

Also at some point the toc pages we link to switched from adoc to md, so this fixes those links too.