### PR TITLE
Fix twitter cards

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -124,7 +124,11 @@ func syncGoMod() error {
 }
 
 func getBaseUrl() string {
-	return os.Getenv("DEPLOY_PRIME_URL") + "/"
+	host := os.Getenv("DEPLOY_PRIME_URL")
+	if host != "" {
+		return host + "/"
+	}
+	return "https://contribute.cncf.io/"
 }
 
 // Create go.local.mod with any appropriate replace statements, and


### PR DESCRIPTION
The twitter card links rely on the domain of the website being set so that it can be an absolute URL that includes the host, e.g. https://contribute.cncf.io/featured-image.png instead of /featured-image.png

Netlify doesn't set DEPLOY_PRIME_URL for production deployments so I have set the build script to default to that domain when its unset.
