### PR TITLE
Add the Mentoring WG

### DIFF
--- a/mentoring/README.md
+++ b/mentoring/README.md
@@ -1,0 +1,83 @@
+# Mentoring WG Charter
+
+## Introduction
+
+The CNCF participates in and runs several mentorship programs throughout the year. These mentoring initiatives should be administered by, and be accountable to, the wider CNCF community.
+
+## Mission
+
+Encourage cloud native computing adoption by providing opportunities for a diverse group of new contributors to work on CNCF projects with experienced mentorship.
+
+## Goals
+
+* Increase CNCF project participation in mentoring programs external to the Linux Foundation
+* Increase the number of CNCF projects and mentee participation in the LFX Mentorship program
+* Increase the quality of mentorship that CNCF projects provide across all mentorship initiatives
+* Explore opportunities for CNCF participation in new mentorship initiatives.
+* Diversity in participants, both mentees and mentors
+* Increase both code and non-code projects
+* Develop mentorship
+    * Provide a path for mentees to become mentors
+    * Provide education for mentors
+
+## Scope and Ownership
+
+The TAG Contributor Strategy Mentoring Working Group manages the following mentorship initiatives:
+
+* The CNCF portion of LFX Mentorship (formerly Community bridge)
+* Google Summer of Code
+* Google Season of Docs
+* Outreachy
+* Other initiatives as desired 
+
+The Mentoring WG owns and maintains the following resources:
+
+* The Mentoring documentation directory in `cncf/tag-contributor-strategy`
+* The `cncf/mentoring` repository
+* Any pages in contribute.cncf.io about mentoring
+* CNCF accounts for for the above Mentoring initiatives
+
+### Contact
+
+* Github discussions for external communications with participants (mentors and mentees)
+    * [https://github.com/cncf/mentoring/discussions](https://github.com/cncf/mentoring/discussions) ([https://mentoring.cncf.io/discussions](https://mentoring.cncf.io/discussions)) 
+* CNCF email list for administration (public)
+    * [tag-cs-mentoring-wg@cncf.io](mailto:tag-cs-mentoring-wg@cncf.io) 
+* CNCF email list for private administrative issues
+    * [tag-cs-mentoring-wg-admin@cncf.io](mailto:tag-cs-mentoring-wg-admin@cncf.io) 
+* CNCF Slack
+    * #tag-contributor-strategy
+    * #mentoring
+* Website
+    * [https://mentoring.cncf.io](https://mentoring.cncf.io) (Currently redirects to [https://github.com/cncf/mentoring](https://github.com/cncf/mentoring))
+
+## Documentation
+
+Official documentation is organized and published in the[ https://github.com/cncf/mentoring/](https://github.com/cncf/mentoring/) repository.
+
+Draft documents can be written up using the HackMD team space:[ https://hackmd.io/team/tag-cs-mentoring-wg](https://hackmd.io/team/tag-cs-mentoring-wg).
+
+## Meetings
+
+Meetings to occur monthly, with extra meetings to manage special events and high effort parts of the mentoring schedule as needed. Calendar to be published on the CNCF public events calendar, and invites sent out upon joining the email list.
+
+Initial meetings are biweekly, on the 2nd and 4th Tuesday of each month, at 20:00 UTC.  This meeting time may be updated in the future.
+
+## Chairs
+
+* Nate Waddington (Linux Foundation/CNCF)
+* Jay Tihema (ii)
+
+## Interested parties
+
+* Ihor Dvoretsky (CNCF)
+* Hippie Hacker (ii)
+* Josh Berkus (Red Hat)
+* Aishwarya Palekar (tentative)
+* Ella Dunlop (ii)
+* Ben Whatarau (ii)
+* Bill Mulligan (Isovalent)
+* Kunal Kushwaha (Civo)
+* Kiran Mova (VMware)
+* Natali Vlatko (Wayfair)
+* Joshua Bezaleel Abednego (Shipper)


### PR DESCRIPTION
This PR creates the Mentoring Working Group officially by adding a charter for it.  See the charter for further information.

Approvals:
@nate-double-u 
@geekygirldawn 
@dims, @mattfarina, @kgamanji 
