### PR TITLE
Fix typo

### DIFF
--- a/website/content/maintainers/github/issue-labels.md
+++ b/website/content/maintainers/github/issue-labels.md
@@ -55,7 +55,7 @@ marked with the "help wanted" label should:
 - **Medium to Low Priority**
 
   Select issues that aren't in key pathways, or must be done quickly. You don't
-  wan to put effort into grooming these issues, then end up having to do it
+  want to put effort into grooming these issues, then end up having to do it
   yourself because it must be done soon.
 
 - **Up-To-Date**


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

Fix a typo in website docs that I just encountered. `"wan to" -> "want to"`
