### PR TITLE
Unpin the contributors subsection

### DIFF
--- a/website/go.mod
+++ b/website/go.mod
@@ -2,4 +2,4 @@ module github.com/cncf/sig-contributor-strategy/website
 
 go 1.15
 
-require github.com/cncf/contribute v0.0.0-20220522133236-120cd52acd17 // indirect
+require github.com/cncf/contribute main // indirect


### PR DESCRIPTION
I accidentally pinned the contributors section of the site (which is located in another repository) to a specific version of that repository in #181 (videos page).

This reverts that change and goes backt to always using the latest from the main branch of https://github.com/cncf/contribute
