### PR TITLE
Add sync from main to drafts

### DIFF
--- a/.github/workflows/drafts.yml
+++ b/.github/workflows/drafts.yml
@@ -1,0 +1,19 @@
+name: Sync Drafts Branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-drafts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Sync Drafts Branch
+        uses: devmasx/merge-branch@v1.3.1
+        with:
+          type: now
+          from_branch: main
+          target_branch: drafts
+          github_token: ${{ github.token }}


### PR DESCRIPTION
This copies the sync job from the main branch to the drafts branch that we currently use for the project-template repository.

When I switched from having a staging branch to using a drafts branch, the sync got accidentally deleted and this brings it back.

After this is merged into drafts, I'll submit 1 more PR to merge into main. Then going forward whenever a PR targets main directly, this should help keep drafts and main in sync. Merge conflicts as always need to be resolved by people manually.