### PR TITLE
Update contributing docs to say where project data comes from

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ you.
 
 This [TAG] (Technical Advisory Group) is an extension of the [TOC] that works to
 build programs and guidance to help scale and grow open source communities. We
-work in two CNCF GitHub repositories:  
+work in this GitHub repository:  
 
 🆕[cncf/tag-contributor-strategy]  
  contains our meta docs that cover our governance, how we operate, and resources that we
@@ -18,10 +18,7 @@ work in two CNCF GitHub repositories:
  web pages at [contribute.cncf.io/maintainers][maintainers] and is advice for people who
  are running and maintaining CNCF projects.
 
-🔜[cncf/contribute]  
-houses contributing information and guidance for people who are contributors
-or aspire to be contributors to CNCF projects. This content is available on our
-website at [contribute.cncf.io/contributors][contributors].
+Note: Project data listed in [the Contributors section](https://contribute.cncf.io/contributors/) is pulled from the [CNCF landscape](https://landscape.cncf.io/). Submit a PR to [the landscape repo](https://github.com/cncf/landscape) to update any project data.
 
 Our [charter] describes our mission and initial scope of what we’d like to
 accomplish. Each of our members are closely involved with at least one CNCF

--- a/website/content/about/contributing.md
+++ b/website/content/about/contributing.md
@@ -45,21 +45,13 @@ Targets:
 
 ## Content Organization
 
-The main website and the "Maintainers" section is in the [TAG Contributor Strategy repository]. 
+The website is in the [TAG Contributor Strategy repository]. 
 
 1. Clone the [TAG Contributor Strategy repository].
 1. Follow the steps to [Preview your changes locally](#preview-your-changes-locally).
-1. Optionally clone the [cncf/contribute repository] in a directory
-    next to the TAG Contributor Strategy repository to edit content
-    in the "Contributors" section.
-    
-    For example, if you have cloned the Contributor Strategy repo to 
-    `~/src/tag-contributor-strategy`, clone the CNCF Contribute repo to
-    `~/src/contribute`.
 
-If you need to clone the CNCF Contribute repository elsewhere, set an environment
-variable named `CONTRIBUTE_REPO` to the path where it is cloned. For example, 
-`export CONTRIBUTE_REPO=../cncf-contribute`.
+Note: Project data listed in [the Contributors section](https://contribute.cncf.io/contributors/) is pulled from the [CNCF landscape](https://landscape.cncf.io/). Submit a PR to [the landscape repo](https://github.com/cncf/landscape) to update any project data.
+
 
 ## Quick start with Netlify
 


### PR DESCRIPTION
These changes should make it clear to people where the project data comes from so that they don't try and update it themselves in this repo.

Signed-off-by: cjyabraham <cjyabraham@gmail.com>
