### PR TITLE
Update mentoring wg mission statement

### DIFF
--- a/mentoring/README.md
+++ b/mentoring/README.md
@@ -6,7 +6,10 @@ The CNCF participates in and runs several mentorship programs throughout the yea
 
 ## Mission
 
-Encourage cloud native computing adoption by providing opportunities for a diverse group of new contributors to work on CNCF projects with experienced mentorship.
+The Mentoring Working Group
+- Encourages cloud native computing adoption by providing opportunities for a diverse group of new contributors to work on CNCF projects with experienced mentorship.
+- Promotes growth and sustainability of projects through mentoring new and existing contributors.
+- Provides support and advice to CNCF projects around mentorship initiatives.
 
 ## Goals
 


### PR DESCRIPTION
This PR updates the mission statement for the mentoring wg which was originally merged in https://github.com/cncf/tag-contributor-strategy/pull/236.

It had to be reverted because I didn't get TOC approval before merging. This adds it back so that we can get approval before it goes live.