### PR TITLE
Fix governance meeting link with tockify meeting link

### DIFF
--- a/governance/README.md
+++ b/governance/README.md
@@ -41,7 +41,7 @@ The following contributors are currently "members" of this working group:
 ## Meetings
 
 We meet once a month.
-Go to [the CNCF calendar](https://www.cncf.io/calendar/) and enter "Governance WG" in the search box to see when we meet next.
+Go to [the CNCF calendar](https://tockify.com/cncf.public.events/monthly?search=Governance+WG) and enter "Governance WG" in the search box to see when we meet next.
 
 Discussion happens on the [contributor strategy mailing list](https://lists.cncf.io/g/cncf-tag-contributor-strategy) or on #tag-contributor-strategy on [CNCF slack](https://slack.cncf.io/).
 


### PR DESCRIPTION
Signed-off-by: dankingkong <115595665+dankingkong@users.noreply.github.com>

Updated the link as per https://github.com/cncf/tag-contributor-strategy/issues/197