### PR TITLE
Update Maintainer's Circle info

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,8 @@ Status: [Proposed](https://github.com/cncf/tag-contributor-strategy/issues/1)
 
 Facilitators:
 
+- Dave Sudia ([@thedevelopnik](https://github.com/thedevelopnik)), Ambassador Labs
 - Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple
-- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco
-- Zach Corleissen ([@zacharysarah](https://github.com/zacharysarah)), Linux Foundation
 
 ### Inclusiveness Team
 

--- a/maintainers-circle/README.md
+++ b/maintainers-circle/README.md
@@ -53,12 +53,24 @@ In-person at KubeCon
 Meetings are scheduled ad-hoc when we have a topic and speaker.
 Join our <a href="https://lists.cncf.io/g/cncf-tag-contributor-strategy">mailing list</a> or our #maintainers-circle channel in the CNCF Slack to be notified of the next event.
 
-## What  
+## What 
 
-### April 8th @ 10:30am PT / 6:30pm GMT / [Your timezone here](https://time.is/compare/1030AM_08_Apr_2021_in_PT)
+### February 13th, 2023 @ 8:00am PT / 4:00pm GMT / [Your timezone here](https://time.is/compare/800AM_13_Feb_2023_in_PT)
 
-TBU
+Non-Code Contributors in the Project Ladder and as Maintainers with Kim McMahon
 
+Bio: Kim McMahon is well-known in the cloud native ecosystem for leading the open source marketing and community activities at organizations such as Dell, Oracle, Kyverno / Nirmata, CNCF, and now Cisco. Community building, breaking down barriers, and uniting are Kim’s drivers. In her free time, Kim enjoys downhill skiing, hiking, cooking, and training her Chocolate Labrador puppy.
+
+**Registration** is an emoji reaction to the invite on the future thread in 
+#maintainer-circle   
+
+**Notes:** https://hackmd.io/MQMFQwnxRZ68Cp7rJLyEvA
+
+**First half**   
+It is not questioned that non-code contributions to an open source project are important. But did you know that the CNCF does not have a clear project ladder for non-code contributors to get to maintainer status and only one CNCF project has a two-pronged approach to reaching maintainer status? In this Maintainer’s Circle talk, we will share with you the project within the TAG Contributor Strategy, the proposed solution, the roll-out plan, and seek your feedback on the gaps and misses you see in the plan.
+
+**Breakout**   
+What challenges have you faced with non-code contributors and growing that community and contributions? How could your project use this ladder to improve your practices? Do you have feedback on the ladder and how it can improve?
 
 ### March 11th @ 10:30am PT / 6:30pm GMT / [Your timezone here](https://time.is/compare/1030AM_11_Mar_2021_in_PT)
 

--- a/maintainers-circle/hosting-guide.md
+++ b/maintainers-circle/hosting-guide.md
@@ -32,10 +32,12 @@ they want to meet.
 ### Calendar and Promotion  
 
 Promotion should start as soon as the speaker and abstract is confirmed with a save the date
-1. Ask Amye or another CNCF staff member to change sig-contributor strategy's
-Thursday meeting to [Maintainers Circle] - [topic] in calendar event name and abstract in the description
-with content both sessions. 
-2. Ask Amye to email maintainers@ cncf list with info about the event. Previous
+1. Find a time with the speaker(s) that
+  1. Fits your and their schedule
+  1. Is ideally early in the morning or late in the evening Pacific Time, so that it is convenient for Europe or Asia/Pacific maintainers.
+  1. Doesn't conflict w/ many other things on the [CNCF Calendar](https://www.cncf.io/calendar/).
+1. Email projects@ cncf.io to request that the event be added to the calendar, with a Zoom meeting assigned to it.
+2. Ask the Projects team to email the maintainers@ cncf list with info about the event. Previous
 emails can be used as a template. Make sure to over emphasize that other core
 decision makers (committee members, etc), reviewers and other maintainer-like
 roles are invited and not just authors and/or solely MAINTAINERS.md. 


### PR DESCRIPTION
Changes:
1. Updates Maintainer's Circle facilitators list to add Dave Sudia and remove people who have moved on
1. Adds a February 13th, 2023 Maintainer's Circle entry
1. Updates the Maintainer's Circle hosting guide with new instructions

I still need to get the date confirmed with the Projects team so please hold on merging until I confirm that, but I wanted to get the PR open to lend some credence to me being someone who _should_ be asking the Projects team to schedule something.
