### PR TITLE
Updated the contributor strategy calendar link. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The [TAG Contributor Strategy charter](/CHARTER.md) outlines the scope of our gr
 ## Meetings
 
 We have one general meeting a month, along with meetings for our working groups.
-Go to [the CNCF calendar](https://www.cncf.io/calendar/) and enter "TAG Contributor Strategy" in the search box to see when we meet next.
+Go to [the CNCF calendar](https://tockify.com/cncf.public.events/monthly?search=Contributor+Strategy) to see when we meet next.
 
 - Calendar invites are sent to the mailing list(see: [Communicating with us](#communicating-with-us)).
 Once you join, you won't automatically have the invite on your calendar. You can

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -56,7 +56,7 @@ Don't see your name? That was an oversight! Open a PR and add yourself. ❤️
 ## Meetings
 
 We meet once a month.
-Go to [the CNCF calendar](https://tockify.com/cncf.public.events/monthly?search=Contributor+Growth+WG) and enter "Contributor Growth WG" in the search box to see when we meet next.
+Go to [the CNCF calendar](https://tockify.com/cncf.public.events/monthly?search=Contributor+Growth+WG) to see when we meet next.
 
 Discussion happens on the [mailing list] or on #tag-contributor-strategy on [Slack].
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -41,7 +41,7 @@ The following contributors are currently "members" of this working group:
 ## Meetings
 
 We meet once a month.
-Go to [the CNCF calendar](https://tockify.com/cncf.public.events/monthly?search=Governance+WG) and enter "Governance WG" in the search box to see when we meet next.
+Go to [the CNCF calendar](https://tockify.com/cncf.public.events/monthly?search=Governance+WG) to see when we meet next.
 
 Discussion happens on the [contributor strategy mailing list](https://lists.cncf.io/g/cncf-tag-contributor-strategy) or on #tag-contributor-strategy on [CNCF slack](https://slack.cncf.io/).
 


### PR DESCRIPTION
Signed-off-by: dankingkong <mr.kingdaniel@gmail.com>

Updated the link as per #197

Contributor Strategy calendar has been updated.

I also noticed that some of the wording after the calendar links was not needed, so I have deleted that so its less confusing.
 
