### PR TITLE
Update template list

### DIFF
--- a/website/content/maintainers/templates/_index.md
+++ b/website/content/maintainers/templates/_index.md
@@ -44,21 +44,23 @@ when you view the markdown file in GitHub unless you view the raw text.
 
 ## Available Templates
 
-* [LICENSE](https://github.com/cncf/project-template/blob/main/LICENSE)
-* [CONTRIBUTING.md](https://github.com/cncf/project-template/blob/main/CONTRIBUTING.md)
-* [README-template.md](https://github.com/cncf/project-template/blob/main/README-template.md)
 * [CODE_OF_CONDUCT.md](https://github.com/cncf/project-template/blob/main/CODE_OF_CONDUCT.md)
-* [SECURITY.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/SECURITY.md)
-* [CONTRIBUTOR_LADDER.md](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md)
-* [GOVERNANCE-elections.md](https://github.com/cncf/project-template/blob/main/GOVERNANCE-elections.md)
-* [GOVERNANCE-maintainer.md](https://github.com/cncf/project-template/blob/main/GOVERNANCE-maintainer.md)
-* [GOVERNANCE-subprojects.md](https://github.com/cncf/project-template/blob/main/GOVERNANCE-subprojects.md)
-* [MAINTAINERS.md](https://github.com/cncf/project-template/blob/main/MAINTAINERS.md)
-* [SECURITY_CONTACTS.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/SECURITY_CONTACTS.md)
-* [ISSUE_TEMPLATE.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/ISSUE_TEMPLATE.md)
-* [embargo-policy.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/embargo-policy.md)
-* [embargo.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/embargo.md)
-* [incident-response.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/incident-response.md)
+* [CONTRIBUTING.md](https://github.com/cncf/project-template/blob/main/CONTRIBUTING.md)
+* [LICENSE](https://github.com/cncf/project-template/blob/main/LICENSE)
+* Governance
+  * [CONTRIBUTOR_LADDER.md](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md)
+  * [GOVERNANCE-elections.md](https://github.com/cncf/project-template/blob/main/GOVERNANCE-elections.md)
+  * [GOVERNANCE-maintainer.md](https://github.com/cncf/project-template/blob/main/GOVERNANCE-maintainer.md)
+  * [GOVERNANCE-subprojects.md](https://github.com/cncf/project-template/blob/main/GOVERNANCE-subprojects.md)
+  * [MAINTAINERS.md](https://github.com/cncf/project-template/blob/main/MAINTAINERS.md)
+* Security
+  * [ISSUE_TEMPLATE.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/ISSUE_TEMPLATE.md)
+  * [SECURITY.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/SECURITY.md)
+  * [SECURITY_CONTACTS.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/SECURITY_CONTACTS.md)
+  * [embargo-policy.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/embargo-policy.md)
+  * [embargo.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/embargo.md)
+  * [incident-response.md](https://github.com/cncf/tag-security/blob/main/project-resources/templates/incident-response.md)
+* [README.md](https://github.com/cncf/project-template/blob/main/README-template.md)
 * [REVIEWING.md](https://github.com/cncf/project-template/blob/main/REVIEWING.md)
 
 [contrib-strat]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md

--- a/website/content/maintainers/templates/_index.md
+++ b/website/content/maintainers/templates/_index.md
@@ -33,14 +33,14 @@ when you view the markdown file in GitHub unless you view the raw text.
 
 ## How-To Guides
 
-* [CONTRIBUTING.md](contributing.md)
-* [Governance Introduction](governance-intro.md)
-* [GOVERNANCE-elections.md](governance-elections.md)
-* [GOVERNANCE-maintainer.md](governance-maintainer.md)
-* [GOVERNANCE-subprojects.md](governance-subprojects.md)
-* [MAINTAINERS.md](maintainers.md)
-* [REVIEWING.md](reviewing.md)
-* [Issue Labels](issue-labels.md)
+* [HowTo: Make a Contributing Guide](contributing.md)
+* [Using the Governance Templates](governance-intro.md)
+  * [The Steering Committee Elections Template](governance-elections.md)
+  * [The Maintainer Council Template](governance-maintainer.md)
+  * [The Governance By Subprojects Template](governance-subprojects.md)
+* [Maintainer List Template](maintainers.md)
+* [HowTo: Make a Reviewing Guide](reviewing.md)
+* [Issue Labels for New Contributors](issue-labels.md)
 
 ## Available Templates
 


### PR DESCRIPTION
[List how to guides by the page title and not file name](https://github.com/cncf/tag-contributor-strategy/commit/98ace9a9ca87bf44c3c8a1e69eebd7035a74dc88)

The How To guides were being listed by the file name in the tag repository, which isn't as helpful to users, especially for accessibility and navigating links. I've updated the how to listing so that it uses the page titles instead.

[Sort and group available templates](https://github.com/cncf/tag-contributor-strategy/commit/f81591a924a64d42cfce77953cf0bb785b6b29a6)

I have updated the list of available templates to be in alphabetical order and in some cases grouped by its area of concern (such as governance or security) so that it's easier to find a specific template.

A preview is available at https://deploy-preview-337--cncf-contribute.netlify.app/maintainers/templates/

This is a follow-up PR addressing my suggestions on #334 