### PR TITLE
Fix links to sample-instructions.png

### DIFF
--- a/website/content/maintainers/templates/contributing.md
+++ b/website/content/maintainers/templates/contributing.md
@@ -28,7 +28,7 @@ The [CONTRIBUTING.md template](https://github.com/cncf/project-template/blob/mai
 Copy the template file into your repository.
 There are instructions for filling out the template that look like the example below:
 
-![screenshot of the CONTRIBUTING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](/maintainers/github/templates/sample-instructions.png)
+![screenshot of the CONTRIBUTING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](sample-instructions.png)
 
 Some links are specific to your project.
 Search for the word TODO in the markdown for links that need to be customized.

--- a/website/content/maintainers/templates/governance-maintainer.md
+++ b/website/content/maintainers/templates/governance-maintainer.md
@@ -32,7 +32,7 @@ Copy the template file into your repository, and rename it `GOVERNANCE.md`.
 
 There are instructions for filling out the template that look like the example below:
 
-![screenshot of the CONTRIBUTING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](/maintainers/github/templates/sample-instructions.png)
+![screenshot of the CONTRIBUTING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](sample-instructions.png)
 
 Some links are specific to your project.
 Search for the word TODO in the markdown for links that need to be customized.

--- a/website/content/maintainers/templates/governance-subprojects.md
+++ b/website/content/maintainers/templates/governance-subprojects.md
@@ -30,7 +30,7 @@ Copy the template file into your repository, and rename it `GOVERNANCE.md`.
 
 There are instructions for filling out the template that look like the example below:
 
-![screenshot of the CONTRIBUTING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](/maintainers/github/templates/sample-instructions.png)
+![screenshot of the CONTRIBUTING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](sample-instructions.png)
 
 Some links are specific to your project.
 Search for the word TODO in the markdown for links that need to be customized.

--- a/website/content/maintainers/templates/maintainers.md
+++ b/website/content/maintainers/templates/maintainers.md
@@ -26,7 +26,7 @@ Copy the template file into your repository.
 
 There are instructions for filling out the template that look like the example below:
 
-![screenshot of the CONTRIBUTING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](/maintainers/github/templates/sample-instructions.png)
+![screenshot of the CONTRIBUTING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](sample-instructions.png)
 
 Some links are specific to your project.
 Search for the word TODO in the markdown for links that need to be customized.

--- a/website/content/maintainers/templates/reviewing.md
+++ b/website/content/maintainers/templates/reviewing.md
@@ -28,7 +28,7 @@ The [REVIEWING.md template](https://github.com/cncf/project-template/blob/main/R
 Copy the template file into your repository.
 There are instructions for filling out the template that look like the example below:
 
-![screenshot of the REVIEWING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](/maintainers/github/templates/sample-instructions.png)
+![screenshot of the REVIEWING.md template, there is a link to instructions, and a warning emoji with text explaining how to fill out this section of the template](sample-instructions.png)
 
 When you finish editing the template, remove the Instruction links that explain how to fill out the template. Also remove any ⚠️ prompts and their explanatory text.
 


### PR DESCRIPTION
Since png files don't have yaml text at the top for redirects, I just realized that when I re-organized the templates content, I broke all of the links to the sample-instructions.png file. This commit fixes those links.

