### PR TITLE
Remove Catherine from Contributor Growth WG leads

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ Facilitators:
 Facilitators:
 
 - Carolyn Van Slyck ([@carolynvs](https://github.com/carolynvs)), Microsoft
-- Catherine Paganini ([@CathPag](https://github.com/CathPag)), Buoyant
 
 ### Maintainer's Circle
 


### PR DESCRIPTION
This change was made months ago and our README is just lagging.

