### PR TITLE
Update TAG about page on website

### DIFF
--- a/website/content/about/_index.html
+++ b/website/content/about/_index.html
@@ -105,8 +105,7 @@ Connect with other maintainers, share best practices, commiserate and grow.
 {{% blocks/section color="gray-300" %}}
 
 {{% blocks/feature icon="fas fa-video" title="Meetings" %}}
-Go to <a href="https://www.cncf.io/calendar/">cncf.io/calendar</a> and enter
-"TAG Contributor Strategy" in the search box to see when we meet next.
+View our <a href="https://tockify.com/cncf.public.events/monthly?search=Contributor+Strategy">calendar</a> to see when we meet next.
 
 Calendar invites are sent to the <a href="https://lists.cncf.io/g/cncf-tag-contributor-strategy">mailing list</a>. Once you join, you won't
 automatically have the invite on your calendar. You can get it from a <a href="https://lists.cncf.io/g/cncf-tag-contributor-strategy/message/1">past
@@ -131,10 +130,12 @@ next.
 
 {{% blocks/feature icon="fas fa-user-alt" title="Leadership" %}}
 
-Dawn Foster (<a href="https://github.com/geekygirldawn">@geekygirldawn</a>), VMware
-
-Josh Berkus (<a href="https://github.com/jberkus">@jberkus</a>), Red Hat
-
+<ul>
+	<li>Dawn Foster (<a href="https://github.com/geekygirldawn">@geekygirldawn</a>), VMware</li>
+	<li>Josh Berkus (<a href="https://github.com/jberkus">@jberkus</a>), Red Hat</li>
+	<li>Catherine Paganini (<a href="https://github.com/CathPag">@CathPag</a>), Buoyant
+</ul>
+	
 {{% /blocks/feature %}}
 
 {{% /blocks/section %}}

--- a/website/content/about/_index.html
+++ b/website/content/about/_index.html
@@ -130,11 +130,9 @@ next.
 
 {{% blocks/feature icon="fas fa-user-alt" title="Leadership" %}}
 
-<ul>
-	<li>Dawn Foster (<a href="https://github.com/geekygirldawn">@geekygirldawn</a>), VMware</li>
-	<li>Josh Berkus (<a href="https://github.com/jberkus">@jberkus</a>), Red Hat</li>
-	<li>Catherine Paganini (<a href="https://github.com/CathPag">@CathPag</a>), Buoyant
-</ul>
+<p>Dawn Foster (<a href="https://github.com/geekygirldawn">@geekygirldawn</a>), VMware</p>
+<p>Josh Berkus (<a href="https://github.com/jberkus">@jberkus</a>), Red Hat</p>
+<p>Catherine Paganini (<a href="https://github.com/CathPag">@CathPag</a>), Buoyant</p>
 	
 {{% /blocks/feature %}}
 


### PR DESCRIPTION
Update our about page on the website with a better link to our calendar, and add Catherine to the leadership section.

Preview at https://deploy-preview-358--cncf-contribute.netlify.app/about/