### PR TITLE
Remove stale instructions in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,1 @@
-Thanks for contributing!
 
-If this change is ready to go live immediately, make your pull request against the main branch. Otherwise, make your pull request against the drafts branch.


### PR DESCRIPTION
Our PR template has stale instructions about the drafts branch that no longer applies. After removing that, there isn't anything that needs to be in the template right now. I am leaving it in place so that we can easily edit it later if we find that we have instructions when creating a PR.

Right now it's not terribly helpful and most people don't realize they should remove the text there and edit it, so this should be less confusing!
