### PR TITLE
Add "About Mentoring WG" page on website

### DIFF
--- a/website/content/about/_index.html
+++ b/website/content/about/_index.html
@@ -91,6 +91,12 @@ burning out.
 
 {{% /blocks/feature %}}
 
+{{% blocks/feature icon="fas fa-hand-holding-heart" title="Mentoring"
+url="mentoring/" %}}
+Want to help new contributors get started? We participate in and run several mentorship programs!
+
+{{% /blocks/feature %}}
+
 {{% blocks/feature icon="fas fa-handshake" title="Maintainers Circle"
 url="maintainers-circle/" %}}
 Connect with other maintainers, share best practices, commiserate and grow.

--- a/website/content/about/working-groups/mentoring.md
+++ b/website/content/about/working-groups/mentoring.md
@@ -8,6 +8,8 @@ url: /about/mentoring
 
 Want to help new contributors get started? We participate in and run several mentorship programs!
 
+Read our [Charter](https://github.com/cncf/tag-contributor-strategy/blob/main/mentoring/README.md)
+
 {{% /blocks/lead %}}
 
 <div class="section-group">
@@ -37,16 +39,6 @@ Mentoring Working Group is a group of people who focus on mentorship initiatives
 
 </div>
 <div class="section-group">
-
-{{% blocks/section color="white" %}}
-
-<div>
-
-You may read our charter [here](https://github.com/cncf/tag-contributor-strategy/blob/main/mentoring/README.md).
-
-</div>
-
-{{% /blocks/section %}}
 
 {{% blocks/section color="white" %}}
 

--- a/website/content/about/working-groups/mentoring.md
+++ b/website/content/about/working-groups/mentoring.md
@@ -45,10 +45,10 @@ Mentoring Working Group is a group of people who focus on mentorship initiatives
 <div>
 Mentoring WG manages the following mentorship initiatives:
 
-* [LFX Mentorship (ex-CommunityBridge)](https://mentorship.lfx.linuxfoundation.org): mentoring initiative by the Linux Foundation - [details](https://github.com/cncf/mentoring/tree/main/programs/programs/lfx-mentorship#readme)
-* [Google Summer of Code](https://summerofcode.withgoogle.com/): mentoring program for the open source beginners - [details](https://github.com/cncf/mentoring/tree/main/programs/programs/summerofcode#readme)
-* [Google Season of Docs](https://developers.google.com/season-of-docs): mentoring initiative for the technical writers - [details](https://github.com/cncf/mentoring/tree/main/programs/programs/seasonofdocs#readme)
-* [Outreachy](https://www.outreachy.org): mentoring initiative for the communities traditionally underrepresented in tech - [details](https://github.com/cncf/mentoring/tree/main/programs/programs/outreachy#readme)
+* [LFX Mentorship (ex-CommunityBridge)](https://mentorship.lfx.linuxfoundation.org): mentoring initiative by the Linux Foundation - [details](https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship#readme)
+* [Google Summer of Code](https://summerofcode.withgoogle.com/): mentoring program for the open source beginners - [details](https://github.com/cncf/mentoring/tree/main/programs/summerofcode#readme)
+* [Google Season of Docs](https://developers.google.com/season-of-docs): mentoring initiative for the technical writers - [details](https://github.com/cncf/mentoring/tree/main/programs/seasonofdocs#readme)
+* [Outreachy](https://www.outreachy.org): mentoring initiative for the communities traditionally underrepresented in tech - [details](https://github.com/cncf/mentoring/tree/main/programs/outreachy#readme)
 
 </div>
 

--- a/website/content/about/working-groups/mentoring.md
+++ b/website/content/about/working-groups/mentoring.md
@@ -55,8 +55,41 @@ Mentoring WG manages the following mentorship initiatives:
 </div>
 
 {{% /blocks/section %}}
-
 </div>
+
+<div class="section-group">
+{{< blocks/section color="primary" >}}
+
+## How your community can benefit
+
+Here are some benefits that the Mentoring working group can provide to communities:
+
+* Do the necessary paper work and applications to mentoring programs on behalf of CNCF projects
+* Provide mentors the best practices and resources for managing and interacting with mentees 
+* Guidance and support for an efficient mentorship execution
+* Promote your project's mentoring activities and help you find more mentees and thus more contributors
+
+You may find links to resources in our [repository](https://github.com/cncf/tag-contributor-strategy/blob/main/mentoring/README.md).
+
+{{% /blocks/section %}}
+</div>
+
+<div class="section-group">
+{{< blocks/section color="primary" >}}
+
+## How you can contribute
+
+We are happy to see that you are interested in helping with this working group. We would love to:
+
+* see you as mentors in the mentoring programs we participate in and organize.
+* get feedback about out guides and documentation.
+* see your introduction email on our mailing list / message on our Slack channel.
+* see you attend our meetings where you can contribute ideas and take responsibilities.
+
+{{% /blocks/section %}}
+</div>
+
+
 <div class="section-group">
 
 ## Get involved

--- a/website/content/about/working-groups/mentoring.md
+++ b/website/content/about/working-groups/mentoring.md
@@ -67,6 +67,8 @@ Mentoring WG manages the following mentorship initiatives:
 </div>
 <div class="section-group">
 
+## Get involved
+
 {{< blocks/section color="primary" >}}
 
 {{% blocks/feature title="Meetings" icon="fas fa-video" %}}

--- a/website/content/about/working-groups/mentoring.md
+++ b/website/content/about/working-groups/mentoring.md
@@ -1,0 +1,105 @@
+---
+title: "Mentoring Working Group"
+linkTitle: "Mentoring"
+url: /about/mentoring
+---
+
+{{% blocks/lead color="primary" align="left" %}}
+
+Want to help new contributors get started? We participate in and run several mentorship programs!
+
+{{% /blocks/lead %}}
+
+<div class="section-group">
+
+{{% blocks/section color="dark" %}}
+
+Mentoring Working Group is a group of people who focus on mentorship initiatives to encourage the adoption of cloud native computing. Our mission is to provide opportunities for new contributors to work on CNCF projects with experienced mentorship, which helps to promote growth and sustainability of projects. We also provide support and advice to CNCF projects around mentorship initiatives.
+
+{{% /blocks/section %}}
+
+</div>
+<div class="section-group">
+
+{{% blocks/section color="secondary" %}}
+
+## Goals
+
+* Increase CNCF project participation in mentoring programs external to the Linux Foundation
+* Increase the number of CNCF projects and mentee participation in the LFX Mentorship program
+* Increase the quality of mentorship that CNCF projects provide across all mentorship initiatives
+* Explore opportunities for CNCF participation in new mentorship initiatives.
+* Diversity in participants, both mentees and mentors
+* Increase both code and non-code projects
+* Develop mentorship by providing a path for mentees to become mentors and providing education for mentors
+
+{{% /blocks/section %}}
+
+</div>
+<div class="section-group">
+
+{{% blocks/section color="white" %}}
+
+## Mentoring Programs
+
+<div>
+Mentoring WG manages the following mentorship initiatives:
+
+* [LFX Mentorship (ex-CommunityBridge)](https://mentorship.lfx.linuxfoundation.org): mentoring initiative by the Linux Foundation - [details](https://github.com/cncf/mentoring/tree/main/programs/programs/lfx-mentorship#readme)
+* [Google Summer of Code](https://summerofcode.withgoogle.com/): mentoring program for the open source beginners - [details](https://github.com/cncf/mentoring/tree/main/programs/programs/summerofcode#readme)
+* [Google Season of Docs](https://developers.google.com/season-of-docs): mentoring initiative for the technical writers - [details](https://github.com/cncf/mentoring/tree/main/programs/programs/seasonofdocs#readme)
+* [Outreachy](https://www.outreachy.org): mentoring initiative for the communities traditionally underrepresented in tech - [details](https://github.com/cncf/mentoring/tree/main/programs/programs/outreachy#readme)
+
+</div>
+
+{{% /blocks/section %}}
+
+</div>
+<div class="section-group">
+
+{{< blocks/section color="primary" >}}
+
+{{% blocks/feature title="Meetings" icon="fas fa-video" %}}
+
+<div>
+
+View our [calendar](https://tockify.com/cncf.public.events/monthly?search=CNCF%20TAG%20Contributor%20Strategy%20Mentoring%20WG) to see when we meet next.
+
+</div>
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fas fa-envelope" title="Mailing List"
+url="https://lists.cncf.io/g/tag-cs-mentoring-wg/" url_text="Sign Up"
+%}}
+Keep up-to-date on mentoring programs we manage.
+
+{{% /blocks/feature %}}
+{{< /blocks/section >}}
+
+{{< blocks/section color="gray-300" >}}
+
+{{% blocks/feature icon="fas fa-comments" title="Discuss" url="https://github.com/cncf/mentoring/discussions" url_text="Start a discussion"
+%}}
+
+Have a look at existing discussions or start a new one on our discussion board.
+
+{{% /blocks/feature %}}
+
+{{% blocks/feature title="Slack" icon="fab fa-slack" %}}
+Reach out for any immediate matters at [#mentoring](https://cloud-native.slack.com/archives/CGPK98JNQ) on [CNCF Slack](https://slack.cncf.io)
+
+{{% /blocks/feature %}}
+
+{{< /blocks/section >}}
+
+{{< blocks/section color="primary" >}}
+
+{{% blocks/feature icon="fas fa-info" title="Find out more"
+url="https://github.com/cncf/mentoring" url_text="More information"
+%}}
+More resources are available on our [GitHub repository](https://github.com/cncf/mentoring).
+{{% /blocks/feature %}}
+
+{{< /blocks/section >}}
+
+</div>

--- a/website/content/about/working-groups/mentoring.md
+++ b/website/content/about/working-groups/mentoring.md
@@ -27,6 +27,8 @@ Mentoring Working Group is a group of people who focus on mentorship initiatives
 
 ## Goals
 
+<div class="text-left">
+
 * Increase CNCF project participation in mentoring programs external to the Linux Foundation
 * Increase the number of CNCF projects and mentee participation in the LFX Mentorship program
 * Increase the quality of mentorship that CNCF projects provide across all mentorship initiatives
@@ -34,6 +36,8 @@ Mentoring Working Group is a group of people who focus on mentorship initiatives
 * Diversity in participants, both mentees and mentors
 * Increase both code and non-code projects
 * Develop mentorship by providing a path for mentees to become mentors and providing education for mentors
+
+</div>
 
 {{% /blocks/section %}}
 
@@ -44,7 +48,7 @@ Mentoring Working Group is a group of people who focus on mentorship initiatives
 
 ## Mentoring Programs
 
-<div>
+<div class="text-left">
 Mentoring WG manages the following mentorship initiatives:
 
 * [LFX Mentorship (ex-CommunityBridge)](https://mentorship.lfx.linuxfoundation.org): mentoring initiative by the Linux Foundation - [details](https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship#readme)
@@ -62,6 +66,8 @@ Mentoring WG manages the following mentorship initiatives:
 
 ## How your community can benefit
 
+<div class="text-left">
+
 Here are some benefits that the Mentoring working group can provide to communities:
 
 * Do the necessary paper work and applications to mentoring programs on behalf of CNCF projects
@@ -71,6 +77,8 @@ Here are some benefits that the Mentoring working group can provide to communiti
 
 You may find links to resources in our [repository](https://github.com/cncf/tag-contributor-strategy/blob/main/mentoring/README.md).
 
+</div>
+
 {{% /blocks/section %}}
 </div>
 
@@ -79,12 +87,16 @@ You may find links to resources in our [repository](https://github.com/cncf/tag-
 
 ## How you can contribute
 
+<div class="text-left">
+
 We are happy to see that you are interested in helping with this working group. We would love to:
 
 * see you as mentors in the mentoring programs we participate in and organize.
 * get feedback about out guides and documentation.
 * see your introduction email on our mailing list / message on our Slack channel.
 * see you attend our meetings where you can contribute ideas and take responsibilities.
+
+</div>
 
 {{% /blocks/section %}}
 </div>

--- a/website/content/about/working-groups/mentoring.md
+++ b/website/content/about/working-groups/mentoring.md
@@ -40,6 +40,16 @@ Mentoring Working Group is a group of people who focus on mentorship initiatives
 
 {{% blocks/section color="white" %}}
 
+<div>
+
+You may read our charter [here](https://github.com/cncf/tag-contributor-strategy/blob/main/mentoring/README.md).
+
+</div>
+
+{{% /blocks/section %}}
+
+{{% blocks/section color="white" %}}
+
 ## Mentoring Programs
 
 <div>


### PR DESCRIPTION
"About Mentoring WG" page on the website.

I first tried to mount the README.md file of the mentoring WG directly. That looked terrible with lots of information that's not good on a website page.

I created this page which tries to explain what the WG is, and how a person visiting the website could benefit from it.