### PR TITLE
Fix some outdated info

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,8 @@ channels:
 
 ### TOC Liaisons
 
-- Matt Farina ([@mattfarina](https://github.com/mattfarina)), SUSE
-- Katie Gamanji ([@kgamanji](https://github.com/kgamanji)), Apple
-- Cathy Zhang ([@cathyhongzhang](https://github.com/cathyhongzhang)), Intel 
+- Emily Fox ([@TheFoxAtWork](https://github.com/TheFoxAtWork)), Apple
+- Dave Zolotusky ([@dzolotusky](https://github.com/dzolotusky)), Spotify
 
 ### Emeritus Leads
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ The [TAG Contributor Strategy charter](/CHARTER.md) outlines the scope of our gr
 We have one general meeting a month, along with meetings for our working groups.
 Go to [the CNCF calendar](https://tockify.com/cncf.public.events/monthly?search=Contributor+Strategy) to see when we meet next.
 
-- Calendar invites are sent to the mailing list(see: [Communicating with us](#communicating-with-us)).
-Once you join, you won't automatically have the invite on your calendar. You can
-get it from a [past message here](https://lists.cncf.io/g/cncf-tag-contributor-strategy/message/1)
 - [Meeting minutes and agenda](https://bit.ly/cncf-contribstrat-agenda)
 - All meetings are recorded and can be accessed on the [CNCF TAG Contributor Strategy](https://www.youtube.com/channel/UCCqKWkTM2pkmLwXaj-7AvcA) Youtube channel.
 - Meeting Link: [zoom.us/my/cncftagcontributorstrategy](https://zoom.us/my/cncftagcontributorstrategy)
@@ -53,8 +50,6 @@ channels:
 - [Mailing list](https://lists.cncf.io/g/cncf-tag-contributor-strategy)
   - The mailing list is used for decisions, announcements, and broad communications
   on record for the entire TAG.
-  - Calendar invites will be sent to this address. You can get the calendar
-  invite from a [past message here](https://lists.cncf.io/g/cncf-tag-contributor-strategy/message/2)
 
 - [#tag-contributor-strategy](https://cloud-native.slack.com/archives/CT6CWS1JN) on [CNCF Slack](https://slack.cncf.io/)
   - Real time communication is great! Chat with us here but we might ask you to
@@ -63,6 +58,9 @@ channels:
 - [File an Issue](https://github.com/cncf/tag-contributor-strategy)
   - Working on a project? Have an idea for something we/you should work on? Talk
   about a change you'd like to propose?
+
+- [Attend our meetings](https://tockify.com/cncf.public.events/monthly?search=Contributor+Strategy)
+  - We meet once a month, and we'd love to have you join us!
 
 ## Members
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ channels:
 
 ### TOC Liaisons
 
-- Emily Fox ([@TheFoxAtWork](https://github.com/TheFoxAtWork)), Apple
-- Dave Zolotusky ([@dzolotusky](https://github.com/dzolotusky)), Spotify
+- Matt Farina ([@mattfarina](https://github.com/mattfarina)), SUSE
+- Katie Gamanji ([@kgamanji](https://github.com/kgamanji)), Apple
+- Cathy Zhang ([@cathyhongzhang](https://github.com/cathyhongzhang)), Intel 
 
 ### Emeritus Leads
 

--- a/website/content/about/_index.html
+++ b/website/content/about/_index.html
@@ -107,9 +107,6 @@ Connect with other maintainers, share best practices, commiserate and grow.
 {{% blocks/feature icon="fas fa-video" title="Meetings" %}}
 View our <a href="https://tockify.com/cncf.public.events/monthly?search=Contributor+Strategy">calendar</a> to see when we meet next.
 
-Calendar invites are sent to the <a href="https://lists.cncf.io/g/cncf-tag-contributor-strategy">mailing list</a>. Once you join, you won't
-automatically have the invite on your calendar. You can get it from a <a href="https://lists.cncf.io/g/cncf-tag-contributor-strategy/message/1">past
-	message</a>
 <a href="https://bit.ly/cncf-contribstrat-agenda">Meeting minutes and agenda</a>
 <a href="https://zoom.us/my/cncftagcontributorstrategy">Meeting Link</a>
 {{% /blocks/feature %}}

--- a/website/content/about/_index.html
+++ b/website/content/about/_index.html
@@ -121,19 +121,16 @@ Keep up-to-date on new templates, advisory guides, and what we are planning
 next.
 {{% /blocks/feature %}}
 
-{{% /blocks/section %}}
-
-</div>
-<div class="section-group">
-
-{{% blocks/section color="gray-200" %}}
+{{% blocks/feature title="Slack" icon="fab fa-slack" %}}
+[#tag-contributor-strategy](https://cloud-native.slack.com/archives/CT6CWS1JN) on [CNCF Slack](https://slack.cncf.io)
+{{% /blocks/feature %}}
 
 {{% blocks/feature icon="fas fa-user-alt" title="Leadership" %}}
 
 <p>Dawn Foster (<a href="https://github.com/geekygirldawn">@geekygirldawn</a>), VMware</p>
 <p>Josh Berkus (<a href="https://github.com/jberkus">@jberkus</a>), Red Hat</p>
 <p>Catherine Paganini (<a href="https://github.com/CathPag">@CathPag</a>), Buoyant</p>
-	
+
 {{% /blocks/feature %}}
 
 {{% /blocks/section %}}

--- a/website/content/resources/videos/2022/livestream.md
+++ b/website/content/resources/videos/2022/livestream.md
@@ -2,7 +2,6 @@
 title: "TAG Contributor Strategy Livesteam"
 description: TAG Contributor Strategy is looking for volunteers in mentoring, contributor growth, and advising CNCF projects
 date: "2022-08-09"
-conference: KubeCon Europe
 speakers:
   - name: Catherine Paganini
     url: https://github.com/CathPag

--- a/website/content/resources/videos/2023/helping-open-source-projects-level-up.md
+++ b/website/content/resources/videos/2023/helping-open-source-projects-level-up.md
@@ -1,0 +1,18 @@
+---
+title: "Helping Open-Source Projects Level Up"
+linkTitle: "Helping Open-Source Projects Level Up"
+description: A chat about how the group helps communities have smooth journeys throughout their CNCF project lifecycle
+date: "2023-03-16"
+speakers:
+  - name: Swapnil Bhartiya
+    url: https://www.linkedin.com/in/swapnilbhartiya/
+  - name: Josh Berkus
+    url: https://github.com/jbkerkus
+  - name: Carolyn Van Slyck
+    url: https://github.com/carolynvs
+youtubeID: PHSk1Wtm04g
+---
+
+The Cloud Native Computing Foundation (CNCF) is a nonprofit that supports and fosters a large number of cloud-native projects. The Contributor Strategy committee advises CNCF projects on strategies related to building, scaling, and retaining contributor communities, including governance, communications, operations, and tools.
+
+In this episode of TFiR: Let’s Talk, Swapnil Bhartiya sits down with Technical Lead – Contributor Strategy Carolyn Van Slyck and Chair – Contributor Strategy Josh Berkus to talk about how the committee helps communities have smooth journeys throughout their CNCF project lifecycle.


### PR DESCRIPTION
Fixes https://github.com/cncf/tag-contributor-strategy/issues/374

Fix the issues mentioned in https://github.com/cncf/tag-contributor-strategy/issues/374, except the mentoring page which is handled in https://github.com/cncf/tag-contributor-strategy/pull/379

### NOTE
Please review commit-by-commit here: https://github.com/cncf/tag-contributor-strategy/pull/380/commits