### PR TITLE
Rewrite contributors entry page with quick fixes

### DIFF
--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Contribution Guides to the CNCF Ecosystem
+title: Contribute to the CNCF Ecosystem
 linkTitle: "Contributors"
 menu:
   main:
@@ -10,22 +10,51 @@ Welcome! Are you interested in contributing to one of CNCF hosted projects? This
 
 CNCF offers multiple ways to start contributing to the CNCF ecosystem, including either foundation-wide and project-wide opportunities.
 
+Though, contributing to the CNCF ecosystem is not just about coding. There are many other ways to contribute to the CNCF ecosystem, including writing documentation, creating tutorials, bringing ideas to meetings, organizing meetups, and more.
 
-## TOC
+## Open Source Beginners
 
-The CNCF TOC is the technical governing body of the CNCF Foundation. The detailed information on CNCF TOC, including its duties and responsibilities, together with the information on collaboration is listed on [CNCF TOC repo](https://github.com/cncf/toc/).
+Are you new to open source? If so, we recommend checking out our comprehensive guide, ["Start Contributing to Open Source"](getting-started.md). This guide is filled with helpful tips and tricks to help you get started with contributing to open source projects. You'll learn about communities and projects, how to find them, how to conform to community standards, and much more.
 
-## Technical Advisory Groups
+## Contribution Opportunities
 
-CNCF TAGs oversee and coordinate the interests pertaining to a logical area of needs of end users and/or projects. More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/tree/main/tags).
+### Mentorship Programs
 
-_Note: CNCF TAGs were previously named Special Interest Groups (SIGs). Renaming SIGs was discussed in [this GitHub Issue](https://github.com/cncf/toc/issues/549)._
+The Cloud Native Computing Foundation participates in various mentoring programs, including:
 
-## Working Groups
+- [LFX Mentorship](https://github.com/cncf/mentoring/tree/master/lfx-mentorship) (previously known as Community Bridge) by the Linux Foundation
+- [Google Summer of Code](https://github.com/cncf/mentoring/tree/master/summerofcode) (GSoC)
+- [Google Season of Docs](https://github.com/cncf/mentoring/tree/master/seasonofdocs) (GSoD)
+- [Outreachy](https://github.com/cncf/mentoring/tree/master/outreachy)
+
+If you are interested in participating in one of the programs, please check out the [CNCF mentoring repository](https://github.com/cncf/mentoring) for more details.
+
+### Project Opportunities
+
+The CNCF projects are always looking for new contributors. If you're interested in contributing to a CNCF project, check out the following:
+
+- [CNCF Landscape](https://landscape.cncf.io/) - a map of all CNCF projects, along with their maturity level and their category
+- [CLOTributor](https://clotributor.dev/) - a tool that helps you find beginner-friendly tasks in CNCF projects
+- [Projects section below](#projects) - a list of all CNCF projects, with their primary language and brief information on contributing to them
+
+
+### Groups
+
+CNCF Technical Advisory Groups (TAG's) oversee and coordinate the interests pertaining to a logical area of needs of end users and/or projects. More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/tree/main/tags).
 
 Working groups (WG's) are the community-driven groups with the goal of continuous collaboration in the specific areas. CNCF WG's are created and curated by the CNCF TOC and driven by the community members. CNCF TOC repo provides more [details](https://github.com/cncf/toc/tree/master/workinggroups#cncf-working-groups) on the purpose and goals of WG's, together with the [list of them](https://github.com/cncf/toc/blob/master/README.md#working-groups).
 
-## Community Engagement
+If you're interested in contributing to a TAG or a WG, be sure to check out their respective repositories for more information.
+
+Remember, group meetings are open to everyone, with no strings attached. You're welcome to join in on the discussions or simply observe the group activities.
+
+### Meetups
+
+The Cloud Native Computing Foundation supports the worldwide community of the Cloud Native meetups. They are listed on [meetup.com](https://www.meetup.com/pro/cncf/) website.
+
+CNCF is currently working on expanding the Cloud Native community around the globe, and we are happy to accept the new meetup communities to join our network, and become one of the official CNCF meetups.
+
+Are you passionate about Cloud Native technologies and interested in starting a meetup in your area? Look no further than the CNCF Meetups program! Check out the [Meetups repository](https://github.com/cncf/meetups) for more information about the program, including best practices for running successful CNCF Meetups.
 
 ### Ambassadors
 
@@ -34,23 +63,6 @@ Working groups (WG's) are the community-driven groups with the goal of continuou
 Successful ambassadors are people such as bloggers, influencers, evangelists who are already engaged with a CNCF project in some way including contributing to forums, online groups, community events, etc.
 
 Details on the Ambassadors program, and information on how to join CNCF as an Ambassador is available [here](https://github.com/cncf/ambassadors).
-
-### Meetups
-
-The Cloud Native Computing Foundation supports the worldwide community of the Cloud Native meetups. They are listed on [meetup.com](https://www.meetup.com/pro/cncf/) website.
-
-CNCF is currently working on expanding the Cloud Native community around the globe, and we are happy to accept the new meetup communities to join our network, and become one of the official CNCF meetups.
-
-Details on the Meetups program, together with the best practices on running CNCF Meetups is available [here](https://github.com/cncf/meetups).
-
-### Mentorship Programs
-
-The Cloud Native Computing Foundation participates in various mentoring programs, including:
-
-- [LFX Mentorship](https://github.com/cncf/mentoring/tree/master/lfx-mentorship) (previously known as Community Bridge) by the Linux Foundation;
-- [Google Summer of Code](https://github.com/cncf/mentoring/tree/master/summerofcode) (GSoC);
-- [Google Season of Docs](https://github.com/cncf/mentoring/tree/master/seasonofdocs) (GSoD);
-- [Outreachy](https://github.com/cncf/mentoring/tree/master/outreachy)
 
 ## Projects
 
@@ -78,8 +90,3 @@ The Cloud Native Computing Foundation projects are listed [below](projects/), to
 ## Archived Projects
 
 {{< projects level="archived" >}}
-
-
-CNCF is a great place to spend a time learning, coding, participating and contributing. We are an exciting open source foundation with a vibrant community of projects, and we look forward to your application and your project ideas!
-
-CNCF and SoC information is available [here](https://github.com/cncf/soc/blob/master/README.md).

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -87,6 +87,3 @@ The Cloud Native Computing Foundation projects are listed [below](projects/), to
 | ------------------------------------------------------------ | ------------------------- | ------------------ |
 |    [Cloud Native Glossary](projects/#cloud-native-glossary)        |           Definitions       |        Markdown      |     
 
-## Archived Projects
-
-{{< projects level="archived" >}}

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -48,13 +48,11 @@ If you're interested in contributing to a TAG or a WG, be sure to check out thei
 
 Remember, group meetings are open to everyone, with no strings attached. You're welcome to join in on the discussions or simply observe the group activities.
 
-### Meetups
+### Community Groups
 
-The Cloud Native Computing Foundation supports the worldwide community of the Cloud Native meetups. They are listed on [meetup.com](https://www.meetup.com/pro/cncf/) website.
+The Cloud Native Computing Foundation supports the worldwide community of the Cloud Native Community Groups (CNCGs). They are listed on [community.cncf.io](https://community.cncf.io/) website. CNCF is currently working on expanding the Cloud Native community worldwide, and we are happy to accept any new local communities to join our network.
 
-CNCF is currently working on expanding the Cloud Native community around the globe, and we are happy to accept the new meetup communities to join our network, and become one of the official CNCF meetups.
-
-Are you passionate about Cloud Native technologies and interested in starting a meetup in your area? Look no further than the CNCF Meetups program! Check out the [Meetups repository](https://github.com/cncf/meetups) for more information about the program, including best practices for running successful CNCF Meetups.
+Are you passionate about Cloud Native technologies and interested in starting a community group in your area? Look no further than the CNCF Meetups program! Check out the [CNCF Community Groups repository](https://github.com/cncf/communitygroups) for more information about the program, including best practices for running successful CNCF Community Groups.
 
 ### Ambassadors
 

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -35,14 +35,14 @@ The CNCF projects are always looking for new contributors. If you're interested 
 
 - [CNCF Landscape](https://landscape.cncf.io/) - a map of all CNCF projects, along with their maturity level and their category
 - [CLOTributor](https://clotributor.dev/) - a tool that helps you find beginner-friendly tasks in CNCF projects
-- [Projects section below](#projects) - a list of all CNCF projects, with their primary language and brief information on contributing to them
+- [Projects section below](#projects) lists all CNCF projects, with their primary language and brief information on contributing to them
 
 
-### TAGs and WG's
+### TAGs and WGs
 
-CNCF Technical Advisory Groups (TAG's) oversee and coordinate the interests pertaining to a logical area of needs of end users and/or projects. More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/tree/main/tags).
+CNCF Technical Advisory Groups (TAGs) oversee and coordinate the interests pertaining to a logical area of needs of end users and/or projects. More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/tree/main/tags).
 
-Working groups (WG's) are the community-driven groups with the goal of continuous collaboration in the specific areas. CNCF WG's are created and curated by the CNCF TOC and driven by the community members. CNCF TOC repo provides more [details](https://github.com/cncf/toc/tree/master/workinggroups#cncf-working-groups) on the purpose and goals of WG's, together with the [list of them](https://github.com/cncf/toc/blob/master/README.md#working-groups).
+Working groups (WGs) are the community-driven groups with the goal of continuous collaboration in the specific areas. CNCF WGs are created and curated by the CNCF TOC and driven by the community members. CNCF TOC repo provides more [details](https://github.com/cncf/toc/tree/master/workinggroups#cncf-working-groups) on the purpose and goals of WGs, together with the [list of them](https://github.com/cncf/toc/blob/master/README.md#working-groups).
 
 If you're interested in contributing to a TAG or a WG, be sure to check out their respective repositories for more information.
 
@@ -64,7 +64,7 @@ Details on the Ambassadors program, and information on how to join CNCF as an Am
 
 ## Projects
 
-The Cloud Native Computing Foundation projects are listed [below](projects/), together with the brief information on contributing to them.
+The Cloud Native Computing Foundation projects are listed below, together with the brief information on contributing to them.
 
 ## Graduated Projects
 

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -38,7 +38,7 @@ The CNCF projects are always looking for new contributors. If you're interested 
 - [Projects section below](#projects) - a list of all CNCF projects, with their primary language and brief information on contributing to them
 
 
-### Groups
+### TAGs and WG's
 
 CNCF Technical Advisory Groups (TAG's) oversee and coordinate the interests pertaining to a logical area of needs of end users and/or projects. More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/tree/main/tags).
 

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -44,7 +44,7 @@ CNCF Technical Advisory Groups (TAGs) are responsible for overseeing and coordin
 
 Although TAGs are designed to focus on specific areas, you can begin contributing through working groups (WGs) that operate under the TAGs with even more narrow scopes. WGs are community-driven groups that encourage ongoing collaboration in specific areas of interest.
 
-More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md). You can find the list of TAGs [here](https://github.com/cncf/toc/tree/main/tags).
+Learn more about [CNCF TAGs](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md) and view a [list of the CNCF TAGs](https://github.com/cncf/toc/tree/main/tags).
 
 
 ### Community Groups

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -22,10 +22,10 @@ Are you new to open source? If so, we recommend checking out our comprehensive g
 
 The Cloud Native Computing Foundation participates in various mentoring programs, including:
 
-- [LFX Mentorship](https://github.com/cncf/mentoring/tree/master/lfx-mentorship) (previously known as Community Bridge) by the Linux Foundation
-- [Google Summer of Code](https://github.com/cncf/mentoring/tree/master/summerofcode) (GSoC)
-- [Google Season of Docs](https://github.com/cncf/mentoring/tree/master/seasonofdocs) (GSoD)
-- [Outreachy](https://github.com/cncf/mentoring/tree/master/outreachy)
+* [LFX Mentorship (ex-CommunityBridge)](https://mentorship.lfx.linuxfoundation.org): mentoring initiative by the Linux Foundation - [details](https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship#readme)
+* [Google Summer of Code](https://summerofcode.withgoogle.com/): mentoring program for the open source beginners - [details](https://github.com/cncf/mentoring/tree/main/programs/summerofcode#readme)
+* [Google Season of Docs](https://developers.google.com/season-of-docs): mentoring initiative for the technical writers - [details](https://github.com/cncf/mentoring/tree/main/programs/seasonofdocs#readme)
+* [Outreachy](https://www.outreachy.org): mentoring initiative for the communities traditionally underrepresented in tech - [details](https://github.com/cncf/mentoring/tree/main/programs/outreachy#readme)
 
 If you are interested in participating in one of the programs, please check out the [CNCF mentoring repository](https://github.com/cncf/mentoring) for more details.
 

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -59,7 +59,7 @@ Are you passionate about Cloud Native technologies and interested in starting a 
 
 Successful ambassadors are people such as bloggers, influencers, evangelists who are already engaged with a CNCF project in some way including contributing to forums, online groups, community events, etc.
 
-Details on the Ambassadors program, and information on how to join CNCF as an Ambassador is available [here](https://github.com/cncf/ambassadors).
+Details on the Ambassadors program, and information on how to join CNCF as an Ambassador is available at the [Cloud Native Ambassadors repository](https://github.com/cncf/ambassadors).
 
 ## Projects
 

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -38,15 +38,14 @@ The CNCF projects are always looking for new contributors. If you're interested 
 - [Projects section below](#projects) lists all CNCF projects, with their primary language and brief information on contributing to them
 
 
-### TAGs and WGs
+### Technical Advisory Groups (TAGs)
 
-CNCF Technical Advisory Groups (TAGs) oversee and coordinate the interests pertaining to a logical area of needs of end users and/or projects. More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/tree/main/tags).
+CNCF Technical Advisory Groups (TAGs) are responsible for overseeing and coordinating the interests of end users and/or projects within a specific area of focus. These groups hold open meetings that are accessible to anyone without any obligations. You are welcome to participate in discussions or simply observe the group's activities. If you are interested in contributing to a TAG, you can find more information in their respective repositories.
 
-Working groups (WGs) are the community-driven groups with the goal of continuous collaboration in the specific areas. CNCF WGs are created and curated by the CNCF TOC and driven by the community members. CNCF TOC repo provides more [details](https://github.com/cncf/toc/tree/master/workinggroups#cncf-working-groups) on the purpose and goals of WGs, together with the [list of them](https://github.com/cncf/toc/blob/master/README.md#working-groups).
+Although TAGs are designed to focus on specific areas, you can begin contributing through working groups (WGs) that operate under the TAGs with even more narrow scopes. WGs are community-driven groups that encourage ongoing collaboration in specific areas of interest.
 
-If you're interested in contributing to a TAG or a WG, be sure to check out their respective repositories for more information.
+More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/tree/main/tags).
 
-Remember, group meetings are open to everyone, with no strings attached. You're welcome to join in on the discussions or simply observe the group activities.
 
 ### Community Groups
 

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -63,7 +63,7 @@ Details on the Ambassadors program, and information on how to join CNCF as an Am
 
 ## Projects
 
-The Cloud Native Computing Foundation projects are listed below, together with the brief information on contributing to them.
+The Cloud Native Computing Foundation projects are listed below with information on how to contribute.
 
 ## Graduated Projects
 

--- a/website/content/contributors/_index.md
+++ b/website/content/contributors/_index.md
@@ -44,7 +44,7 @@ CNCF Technical Advisory Groups (TAGs) are responsible for overseeing and coordin
 
 Although TAGs are designed to focus on specific areas, you can begin contributing through working groups (WGs) that operate under the TAGs with even more narrow scopes. WGs are community-driven groups that encourage ongoing collaboration in specific areas of interest.
 
-More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/tree/main/tags).
+More details about the CNCF TAGs is available [here](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md). You can find the list of TAGs [here](https://github.com/cncf/toc/tree/main/tags).
 
 
 ### Community Groups


### PR DESCRIPTION
Fixes https://github.com/cncf/tag-contributor-strategy/issues/375

I rewrote the https://contribute.cncf.io/contributors/ page with the structure I mentioned in https://github.com/cncf/tag-contributor-strategy/issues/375

Preview: https://deploy-preview-381--cncf-contribute.netlify.app/contributors/

### Note

Please review commit-by-commit