### PR TITLE
Improve "About Contributor Growth WG" page on the website

### DIFF
--- a/website/content/about/working-groups/contributor-growth.md
+++ b/website/content/about/working-groups/contributor-growth.md
@@ -58,6 +58,19 @@ You may find some tips in our [Community Guide](/maintainers/community/) and [Av
 </div>
 
 <div class="section-group">
+{{< blocks/section color="primary" >}}
+
+## How you can contribute
+
+We are happy to see that you are interested in helping with this working group. We would love to:
+* get your feedback about out guides and templates.
+* see your introduction email on our mailing list / message on our Slack channel.
+* see you attend our meetings where you can contribute ideas and take responsibilities.
+
+{{% /blocks/section %}}
+</div>
+
+<div class="section-group">
 
 ## Get involved
 

--- a/website/content/about/working-groups/contributor-growth.md
+++ b/website/content/about/working-groups/contributor-growth.md
@@ -29,11 +29,15 @@ We aim to provide best practices and resources for managing and interacting with
 
 ## Goals
 
+<div class="text-left">
+
 * Provide best practices and resources for managing and interacting with contributors to CNCF projects.
 * Provide guidance on a sustainable contributor lifecycle for CNCF Projects to:
     * Develop a pipeline that brings in new contributors.
     * Define a contribution ladder with activities that promote contributors to higher levels of responsibility.
     * Support their maintainers with advice and resources that improve sustainability and plan for transitions from the project.
+
+</div>
 
 {{% /blocks/section %}}
 
@@ -44,8 +48,9 @@ We aim to provide best practices and resources for managing and interacting with
 
 ## How your community can benefit
 
-Here are some benefits that the Contributor Growth working group can provide to communities:
+<div class="text-left">
 
+Here are some benefits that the Contributor Growth working group can provide to communities:
 * Best practices and resources for managing and interacting with contributors to CNCF projects
 * Guidance and support for a sustainable contributor lifecycle for CNCF projects
 * Templates for common documents like a contributing guide, reviewing guide, TOC due diligence guidelines, and more
@@ -53,6 +58,7 @@ Here are some benefits that the Contributor Growth working group can provide to 
 * Non-code areas such as project management, work prioritization and similar, which may not be the maintainers' primary skillset
 
 You may find some tips in our [Community Guide](/maintainers/community/) and [Available Templates](/maintainers/templates/).
+</div>
 
 {{% /blocks/section %}}
 </div>
@@ -62,12 +68,16 @@ You may find some tips in our [Community Guide](/maintainers/community/) and [Av
 
 ## How you can contribute
 
+<div class="text-left">
+
 We are happy to see that you are interested in helping with this working group. We would love to:
 * get your feedback about out guides and templates.
 * see your introduction email on our mailing list / message on our Slack channel.
 * see you attend our meetings where you can contribute ideas and take responsibilities.
 
 {{% /blocks/section %}}
+</div>
+
 </div>
 
 <div class="section-group">
@@ -103,10 +113,8 @@ Reach out for any immediate matters at [#tag-contributor-strategy](https://cloud
 
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fas fa-info" title="Find out more"
-url="https://github.com/cncf/tag-contributor-strategy/blob/main/contributor-growth/README.md" url_text="Charter Document"
-%}}
-More resources are available on our Charter document, [Community Guide](/maintainers/community/) and [Available Templates](/maintainers/templates/).
+{{% blocks/feature icon="fas fa-info" title="Find out more" %}}
+More resources are available on our [Charter Document](https://github.com/cncf/tag-contributor-strategy/blob/main/contributor-growth/README.md), [Community Guide](/maintainers/community/) and [Available Templates](/maintainers/templates/).
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}

--- a/website/content/about/working-groups/contributor-growth.md
+++ b/website/content/about/working-groups/contributor-growth.md
@@ -52,6 +52,8 @@ Here are some benefits that the Contributor Growth working group can provide to 
 * Case studies and talks for insights and inspiration
 * Non-code areas such as project management, work prioritization and similar, which may not be the maintainers' primary skillset
 
+You may find some tips in our [Community Guide](/maintainers/community/) and [Available Templates](/maintainers/templates/).
+
 {{% /blocks/section %}}
 </div>
 
@@ -89,9 +91,9 @@ Reach out for any immediate matters at [#tag-contributor-strategy](https://cloud
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fas fa-info" title="Find out more"
-url="https://github.com/cncf/tag-contributor-strategy/blob/main/contributor-growth/README.md" url_text="More information"
+url="https://github.com/cncf/tag-contributor-strategy/blob/main/contributor-growth/README.md" url_text="Charter Document"
 %}}
-More resources are available on our Charter document.
+More resources are available on our Charter document, [Community Guide](/maintainers/community/) and [Available Templates](/maintainers/templates/).
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}

--- a/website/content/about/working-groups/contributor-growth.md
+++ b/website/content/about/working-groups/contributor-growth.md
@@ -75,9 +75,9 @@ We are happy to see that you are interested in helping with this working group. 
 * see your introduction email on our mailing list / message on our Slack channel.
 * see you attend our meetings where you can contribute ideas and take responsibilities.
 
-{{% /blocks/section %}}
 </div>
 
+{{% /blocks/section %}}
 </div>
 
 <div class="section-group">

--- a/website/content/about/working-groups/contributor-growth.md
+++ b/website/content/about/working-groups/contributor-growth.md
@@ -4,18 +4,96 @@ linkTitle: Contributor Growth
 url: /about/contributor-growth/
 ---
 
-We are interested in assisting CNCF projects with sustainably growing their
-contributor base.
+{{% blocks/lead color="primary" align="left" %}}
 
+Want to grow your contributor base sustainably? We can assist you with best practices, resources, and guidance on how!
 
-We meet once a month.
-Go to <a href="https://www.cncf.io/calendar/">cncf.io/calendar</a> and enter "Contributor Growth WG" in the search box to see when we meet next.
+Read our [Charter](https://github.com/cncf/tag-contributor-strategy/blob/main/contributor-growth/README.md)
 
-* [Zoom](https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09) passcode: `77777`
-* [Meeting Minutes and Agenda](https://docs.google.com/document/d/1Kx7tZv5wTXQ7uRKxn5d9d2wLsI3Q3Q51A0i06nLvtdI/edit)
+{{% /blocks/lead %}}
 
-Discussion happens on the [mailing list] or on #tag-contributor-strategy on [Slack].
+<div class="section-group">
 
-[mailing list]: https://lists.cncf.io/g/cncf-tag-contributor-strategy
-[Slack]: https://slack.cncf.io/
+{{% blocks/section color="dark" %}}
 
+The Contributor Growth Working Group is a team within CNCF that focuses on helping CNCF projects grow their contributor base sustainably.
+
+We aim to provide best practices and resources for managing and interacting with contributors to CNCF projects.
+{{% /blocks/section %}}
+
+</div>
+
+<div class="section-group">
+
+{{% blocks/section color="secondary" %}}
+
+## Goals
+
+* Provide best practices and resources for managing and interacting with contributors to CNCF projects.
+* Provide guidance on a sustainable contributor lifecycle for CNCF Projects to:
+    * Develop a pipeline that brings in new contributors.
+    * Define a contribution ladder with activities that promote contributors to higher levels of responsibility.
+    * Support their maintainers with advice and resources that improve sustainability and plan for transitions from the project.
+
+{{% /blocks/section %}}
+
+</div>
+
+<div class="section-group">
+{{< blocks/section color="primary" >}}
+
+## How your community can benefit
+
+Here are some benefits that the Contributor Growth working group can provide to communities:
+
+* Best practices and resources for managing and interacting with contributors to CNCF projects
+* Guidance and support for a sustainable contributor lifecycle for CNCF projects
+* Templates for common documents like a contributing guide, reviewing guide, TOC due diligence guidelines, and more
+* Case studies and talks for insights and inspiration
+* Non-code areas such as project management, work prioritization and similar, which may not be the maintainers' primary skillset
+
+{{% /blocks/section %}}
+</div>
+
+<div class="section-group">
+
+## Get involved
+
+{{< blocks/section color="primary" >}}
+
+{{% blocks/feature title="Meetings" icon="fas fa-video" %}}
+
+<div>
+
+View our [calendar](https://tockify.com/cncf.public.events/monthly?search=Contributor%20Growth%20WG) to see when we meet next.
+
+<a href="https://docs.google.com/document/d/1Kx7tZv5wTXQ7uRKxn5d9d2wLsI3Q3Q51A0i06nLvtdI/edit">Meeting minutes and agenda</a>
+<a href="https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09">Meeting Link</a>
+
+</div>
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fas fa-envelope" title="Mailing List"
+url="https://lists.cncf.io/g/cncf-tag-contributor-strategy" url_text="Sign Up"
+%}}
+Keep up-to-date on mentoring programs we manage.
+
+{{% /blocks/feature %}}
+{{< /blocks/section >}}
+
+{{< blocks/section color="gray-300" >}}
+
+{{% blocks/feature title="Slack" icon="fab fa-slack" %}}
+Reach out for any immediate matters at [#tag-contributor-strategy](https://cloud-native.slack.com/archives/CT6CWS1JN) on [CNCF Slack](https://slack.cncf.io)
+
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fas fa-info" title="Find out more"
+url="https://github.com/cncf/tag-contributor-strategy/blob/main/contributor-growth/README.md" url_text="More information"
+%}}
+More resources are available on our Charter document.
+{{% /blocks/feature %}}
+
+{{< /blocks/section >}}
+
+</div>


### PR DESCRIPTION
Use the structure from other PRs:
- https://github.com/cncf/tag-contributor-strategy/pull/379
- https://github.com/cncf/tag-contributor-strategy/pull/380

Current page was not useful.

Preview: https://deploy-preview-382--cncf-contribute.netlify.app/about/contributor-growth/