### PR TITLE
Remove dependency to archived cncf/contribute repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,6 @@ https://www.firsttimersonly.com/
 [README]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md
 [charter]: https://github.com/cncf/tag-contributor-strategy/blob/main/CHARTER.md
 [working groups]: https://github.com/cncf/tag-contributor-strategy/blob/main/README.md#working-groups
-[cncf/contribute]: https://github.com/cncf/contribute
 [cncf/tag-contributor-strategy]: https://github.com/cncf/tag-contributor-strategy
 [maintainers circle]: https://github.com/cncf/tag-contributor-strategy/issues/1
 [website/content]: website/content/

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -82,6 +82,6 @@ Interisted parties:
 
 # Documentation
 
-Our documentation is shared in the [cncf/contribute] repository.
+Our documentation is shared in the [contribute.cncf.io] website.
 
-[cncf/contribute]: https://github.com/cncf/contribute
+[contribute.cncf.io]: https://contribute.cncf.io/

--- a/website/content/about/contributing.md
+++ b/website/content/about/contributing.md
@@ -140,6 +140,27 @@ image: "https://i.ytimg.com/vi/YOUTUBE_ID/maxresdefault.jpg" # Grab the unique v
 Copy the talk description from the schedule and paste it here. The formatting is probably wrong so spend a bit of time to fix it so that it's not a giant wall of text.
 ```
 
+## Comparing the before and after of your big changes
+
+```shell
+# build the website on your branch
+$> mage build
+
+# create a temporary directory
+$> TMP=$(mktemp -d)
+
+# clone the repo into the temp directory using main branch
+$> git clone --depth 1 https://github.com/cncf/tag-contributor-strategy.git $TMP
+
+# build the main branch of the website using the temp directory
+$> pushd $TMP
+$> mage build
+$> popd
+
+# compare the two builds
+$> diff -r website/public $TMP/website/public
+```
+
 ## Creating an issue
 
 If you've found a problem in the docs, but you're not sure how to fix it

--- a/website/content/about/contributing.md
+++ b/website/content/about/contributing.md
@@ -158,4 +158,3 @@ Issue** button in the top right hand corner of the page.
   basic introduction to GitHub concepts and workflow.
 
 [TAG Contributor Strategy repository]: https://github.com/cncf/tag-contributor-strategy
-[cncf/contribute repository]: https://github.com/cncf/contribute

--- a/website/go.mod
+++ b/website/go.mod
@@ -1,5 +1,3 @@
 module github.com/cncf/sig-contributor-strategy/website
 
 go 1.15
-
-require github.com/cncf/contribute v0.0.0-20220713152120-b39b8edc93eb // indirect


### PR DESCRIPTION
Remove dependency to archived cncf/contribute repository.

Although I wasn't there, what I understand from the Git history and the magefile is that it was added as a temporary dependency. See the old commit message here: https://github.com/cncf/tag-contributor-strategy/commit/c5bba84a15afa943e028d84b3de6a4c4a6039588

Changes:
- Removed the code that was creating a volume mount for cncf/contribute repository, 
- Similarly, removed the volume mount for a _local_ Go mod file. This file was used for the replacement of cncf/contribute with a local repository, in a development setup.
- Removed Go dependency to cncf/contribute
- Added a short instruction in `website/content/about/contributing.md` file about "Comparing the before and after of your big changes". I used this approach to test if my changes break anything or change any content.

**NOTE:** Might be easier to review commit by commit

