### PR TITLE
Add "triage" permission to @aliok

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -14,8 +14,7 @@ repository:
   homepage: https://cncf.io/projects
 
 # Collaborators: give specific users access to this repository.
-# see /governance/roles.md for details on write access policy
-# note that the permissions below may provide wider access than needed for
+# Note that the permissions below may provide wider access than needed for
 # a specific role, and we trust these individuals to act according to their
 # role. If there are questions, please contact one of the chairs.
 collaborators:
@@ -110,6 +109,11 @@ collaborators:
 
   - username: hh
     permission: push
+    
+# collaborators. see https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization
+
+  - username: aliok
+    permission: triage
 
 labels:
   - name: new-wg


### PR DESCRIPTION
Proposing giving `triage` permission to myself to save you some trouble. I can't assign issues to myself currently, nor I can label issues/PRs.

See https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization for the details of `triage` permission.

There's also this one: https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#list-repository-collaborators