### PR TITLE
Upgrade to a newer Hugo version

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -87,25 +87,25 @@ func Hugo() error {
 func Deploy() error {
 	mg.Deps(docsy, syncGoMod, netlifySetup)
 
-	return shx.RunV("hugo", "-s", "website", "--debug", "--verbose", "-b", "https://contribute.cncf.io/")
+	return shx.Command("hugo", "--debug", "--verbose", "-b", "https://contribute.cncf.io/").In("website").RunV()
 }
 
 // Deploy branch builds the website, including future dated and draft posts
 func DeployBranch() error {
 	mg.Deps(docsy, syncGoMod, netlifySetup)
 
-	return shx.RunV("hugo", "-s", "website", "--debug", "--buildDrafts", "--buildFuture", "--verbose", "-b", getBaseUrl())
+	return shx.Command("hugo", "--debug", "--buildDrafts", "--buildFuture", "--verbose", "-b", getBaseUrl()).In("website").RunV()
 }
 
 // Deploy preview builds the website for a pull request, using the same build settings as the live site.
 func DeployPreview() error {
 	mg.Deps(docsy, syncGoMod, netlifySetup)
 
-	return shx.RunV("hugo", "-s", "website", "--debug", "--buildDrafts", "--buildFuture", "--verbose", "-b", getBaseUrl())
+	return shx.Command("hugo", "--debug", "--buildDrafts", "--buildFuture", "--verbose", "-b", getBaseUrl()).In("website").RunV()
 }
 
 func syncGoMod() error {
-	return shx.RunV("go", "mod", "download")
+	return shx.Command("go", "mod", "download").In("website").RunV()
 }
 
 func getBaseUrl() string {

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
   command = "go run mage.go -v Deploy"
 
 [build.environment]
-  HUGO_VERSION = "0.79.0"
+  HUGO_VERSION = "0.107.0"
   HUGO_ENV = "production"
   NODE_VERSION = "12.20.0"
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM klakegg/hugo:0.79.0-ext-alpine
+FROM klakegg/hugo:0.107.0-ext-alpine
 
 # Cache go modules
 WORKDIR /tmp/website


### PR DESCRIPTION
Part of https://github.com/cncf/tag-contributor-strategy/issues/402

### Changes
- Upgrade to a newer Hugo version
- Run `hugo` command in website directory (`cd website; hugo ...`) instead of running it outside (`hugo --source website`). New version of Hugo cannot find the `postcss-cli` installed in the parent directory. `postcss-cli` is a dependency setup in `website/package.json` and not in `/package.json`. Alternative is to install `postcss-cli` with `npm install -g`, which is not ideal.

### Verification
To verify changes that nothing meaningful is changed in the output:

```shell
# build the website on your branch
$> mage build

# create a temporary directory
$> TMP=$(mktemp -d)

# clone the repo into the temp directory using main branch
$> git clone --depth 1 https://github.com/cncf/tag-contributor-strategy.git $TMP

# build the main branch of the website using the temp directory
$> pushd $TMP
$> mage build
$> popd

# compare the two builds
$> diff -r website/public $TMP/website/public
```

Instructions above will give you diffs of built resources (HTML, JS, CSS, etc).

Diffs you will see:
- SVG embeddings in HTML and CSS files: Hugo changed how SVG is embedded; doesn't have a visible effect.
- Some new `meta` tags added by new version of Hugo: doesn't break anything
- "Last modified" datetime of pages
- Escaping of some chars in HTML: Hugo improved the escaping behavior
- JS diffs: Better JS minification in newer Hugo version; no effect
- CSS diffs: Better CSS rendering in newer Hugo version; no effect
