### PR TITLE
Upgrade GitHub actions used

### DIFF
--- a/.github/workflows/updateprojects.yml
+++ b/.github/workflows/updateprojects.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Run build
       run: |
         python .github/workflows/updateprojects.py
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       with:
          token: ${{ secrets.PAT }}
          branch-suffix: timestamp


### PR DESCRIPTION
`actions/checkout` and `actions/setup-python` are used minimally and changing the version will just work.

`peter-evans/create-pull-request` is used in a more sophisticated way but I don't see anything that needs to change when I check the upgrade guide: https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md

Upgrading `peter-evans/create-pull-request` is a good idea IMO, as we will do some changes to how we use it (https://github.com/cncf/tag-contributor-strategy/issues/410, https://github.com/cncf/tag-contributor-strategy/issues/411)