### PR TITLE
No duplicate project update PRs

### DIFF
--- a/.github/workflows/updateprojects.yml
+++ b/.github/workflows/updateprojects.yml
@@ -20,7 +20,7 @@ jobs:
       uses: peter-evans/create-pull-request@v5
       with:
          token: ${{ secrets.PAT }}
-         branch-suffix: timestamp
+         branch: auto-update-projects
          path: .
          title: Update Projects
          labels: automerge


### PR DESCRIPTION
Fixes #410

Apply the fix described in #410 

I created a fork to test this. Manually triggered the "update projects" workflow there.

- I ran as is twice ([first](https://github.com/aliok/tag-contributor-strategy-tmp/actions/runs/5316537186/jobs/9626163349)) ([second](https://github.com/aliok/tag-contributor-strategy-tmp/actions/runs/5316542571/jobs/9626173250)) and saw 2 PRs created ([first](https://github.com/aliok/tag-contributor-strategy-tmp/pull/1)) ([second](https://github.com/aliok/tag-contributor-strategy-tmp/pull/2))
- I made the same change as in this PR there and again ran twice ([first](https://github.com/aliok/tag-contributor-strategy-tmp/actions/runs/5316574356/jobs/9626234698)) ([second](https://github.com/aliok/tag-contributor-strategy-tmp/actions/runs/5316574405/jobs/9626234714)) and saw the second run didn't create a new PR as there was a PR already

```
Branch 'auto-update-projects' is even with its remote and will not be updated
```