### PR TITLE
Update Maintainers Circle label to match the name of the WG

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -128,7 +128,7 @@ labels:
     color: 00ff00
   - name: wg/governance
     color: 2f4f4f
-  - name: wg/maintainer
+  - name: wg/maintainers-circle
     color: 00ffff
   - name: wg/contribgrowth
     color: ff00ff


### PR DESCRIPTION
Expanded the label name to be more clear about it's purpose.