### PR TITLE
adding Diane M. as a Tech lead for Mentoring WG

### DIFF
--- a/mentoring/README.md
+++ b/mentoring/README.md
@@ -64,10 +64,10 @@ Draft documents can be written up using the HackMD team space:[ https://hackmd.i
 
 Meetings to occur monthly, with extra meetings to manage special events and high effort parts of the mentoring schedule as needed. Calendar to be published on the CNCF public events calendar, and invites sent out upon joining the email list.
 
-* [Monthly meeting minutes](https://hackmd.io/@tag-cs-mentoring-wg/monthly-meeting)
+* [Monthly meeting minutes](https://hackmd.io/@tag-cs-mentoring-wg/monthly-meeting-2023)
 * [Calendar](https://tockify.com/cncf.public.events/monthly?search=Mentoring+WG)
 
-Initial meetings are biweekly, on the 2nd and 4th Tuesday of each month, at 20:00 UTC.  This meeting time may be updated in the future.
+Meetings are monthly, on the 2nd Tuesday of each month, at 9:00PM UTC. This meeting time may be updated in the future.
 
 Facilitators:
 
@@ -79,6 +79,10 @@ Facilitators:
 
 * Nate Waddington (Linux Foundation/CNCF)
 * Jay Tihema (ii)
+
+## Tech leads
+
+* Diane Mueller (Bitergia) — Statistics & Reporting lead ([@dmueller2001](https://github.com/dmueller2001))
 
 ## Interested parties
 


### PR DESCRIPTION
As per our [Mentoring WG meeting on July 11, 2023](https://hackmd.io/@tag-cs-mentoring-wg/monthly-meeting-2023?view#July-11-2023), adding @dmueller2001 to the Mentoring WG charter as a Tech Lead.

We're adding her here as there is actually no spot in  the [cncf/mentoring](https://github.com/cncf/mentoring) repo where we list the Mentoring WG leadership, in that repo we just link to this charter.

Since I'm making updates to the charter, I'm also updating:
- current meeting minutes link
- meeting cadence