### PR TITLE
Governance review for the Cilium project

### DIFF
--- a/governance/assessments/projects/cilium/2023-08-22.md
+++ b/governance/assessments/projects/cilium/2023-08-22.md
@@ -8,7 +8,7 @@ Projects may ask TAG Contributor Strategy for assistance in resolving any issues
 
 This is a follow up to the [assessment conducted](https://docs.google.com/document/d/1AMlmAxnljXtQPkYpGbULCZaKzsPaeJxk-GNu1HnvIeE/edit) when the project applied for graduation in January 2023.
 
-Status: Mostly Satisfactory. There is one must-fix item listed below and 2 areas for improvement. The biggest governance concerns are related to the overwhelming majority of contributors who work at Isovalent and the very small number of active maintainers who work at other companies. These concerns are detailed in the sections below. 
+Status: Mostly Satisfactory. There are several areas for improvement listed below. The biggest governance concerns are related to the number of inactive or low activity maintainers. These concerns are detailed in the sections below. 
 
 ### Executing the Assessment
 
@@ -18,12 +18,13 @@ Original assessment in January 2023 was conducted by Josh Berkus (Red Hat) and D
 
 The following issues have been identified that need to be resolved before Graduation:
 
-* Inactive maintainers should be moved to Emeritus
+* None
 
 ### Areas for Improvement
 
 Over the next year, the project should work on the following issues to improve its governance, these are considered non-blocking:
 
+* Inactive maintainers should be moved to Emeritus
 * Recruit more active maintainers from outside of Isovalent
 * Document how SIGs and subprojects relate to project governance
 
@@ -118,9 +119,11 @@ Ownership audit has not been conducted, as the CNCF is not yet ready to provide 
 
 ### Maintainer List(s)
 
-The project's maintainer list(s) is partially current. Individuals on the maintainer list do appear to match the requirements of maintainership in accordance with the project's documented requirements. The maintainer affiliations (employers) reflect Unbalanced diversity with most of the maintainers working for Isovalent; however, there are a few active maintainers who work for other organizations.
+The project's maintainer list(s) is partially current. Individuals on the maintainer list do appear to match the requirements of maintainership in accordance with the project's documented requirements. The maintainer affiliations (employers) reflect Unbalanced diversity with most of the maintainers working for Isovalent; however, there are enough maintainers who work for other organizations to meet the CNCF requirements for graduation.
 
-There are a large number of committers listed in the MAINTAINERS.md file, which shows that quite a few people are engaged in the project on a regular basis, including some non-Isovalent contributors listed as committers. However, some of the committers are inactive and might be removed. Of particular concern is that none of the non-Isovalent committers listed in the MAINTAINERS.md file are continuing to make significant numbers of contributions to the project, and many of them are contributing much less than they were in the previous 3 quarters (with the caveat that the data comes from devstats, which excludes non-code contributions that these people may be making).
+There are a large number of committers listed in the MAINTAINERS.md file, which shows that quite a few people are engaged in the project on a regular basis, including some non-Isovalent contributors listed as committers below. However, some of the committers are inactive and might be moved into Emeritus roles (with the caveat that the data comes from devstats, which excludes non-code contributions that these people may be making). Note that it is up to the Cilium project to define what it means to be "active" within the project. 
+
+This data about non-Isovalent maintainers was gathered in mid-August, so may not include more recent contributions.
 
 * Eloy Coto (Red Hat): hasn’t contributed in the past year.  Verified that they are no longer working on Cillium.
 * Deepesh Pathak: has made no contributions in the past year.
@@ -133,9 +136,14 @@ There are a large number of committers listed in the MAINTAINERS.md file, which 
 * Weilong Cui (Google): has made no contributions in the past quarter (30 contributions in the past year).
 * Yongkun Gui (Google): has made only 7 contributions in the past quarter (34 contributions in the past year), which is a slight increase since the last review.
 
-Most non-Isovalent maintainers (with the exception of Yongkun and Hemanth) have contributed less this quarter / year than when we did the original assessment in January, and there have been no new non-Isovalent maintainers added to the list. The decline in non-Isovalent maintainers feels like a problem that needs to be addressed urgently.
+Most non-Isovalent maintainers (with the exception of Yongkun and Hemanth) have contributed less this quarter / year than when we did the original assessment in January, and there have been no new non-Isovalent maintainers added to the list. The decline in activity for non-Isovalent maintainers feels like a problem that needs to be addressed over time.
 
-For these maintainers in particular, Cilium should verify activity status, and document any whose main contribution is non-code (and thus not appearing in Devstats). While we appreciate the move of a few maintainers to the Emeritus list, the project still needs to retire more of the inactive committers, and given the voting system, the project could be forced to reboot governance due to unability to get a majority.
+For these maintainers in particular, Cilium should verify activity status, and document any whose main contribution is non-code (and thus not appearing in Devstats). While we appreciate the move of a few maintainers to the Emeritus list, the project still could move other inactive committers into an Emeritus role. This is important for a few reasons:
+
+* Given the voting system, the project could be forced to reboot governance due to inability to get a majority. With so many inactive maintainers, it could become difficult or impossible to achieve a majority when voting if people are no longer active in the project. This could delay critical work or cause other disruption within the project.
+* For security reasons, inactive maintainers should have their elevated access within the project removed so that only the people who need elevated access for active maintainer duties have it.
+
+Keep in mind that these people are still part of the community and can continue to contribute. By moving them to Emeritus, they are only being relieved of their maintainer obligations (including voting), but are not being removed from the project or the community. If they should desire to become more involved in the future, they can be moved from Emeritus back into a maintainer role.
 
 The TOC requires maintainers from more than one company for two reasons:
 Demonstrating that the project is open to contributors regardless of employer, which Cilium clearly has, and

--- a/governance/assessments/projects/cilium/2023-08-22.md
+++ b/governance/assessments/projects/cilium/2023-08-22.md
@@ -51,7 +51,7 @@ Governance documentation may be found with [Cilium’s main documentation](https
 
 In general, the definitions and activities of the committers and would-be committers are very well defined.
 
-The project has made a number of improvements to the governance based on our feedback from January, including the addition of a [contributor ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md), improvements to the [roadmap process](https://docs.cilium.io/en/stable/community/roadmap/#influencing-the-roadmap), and links from the governance documents to the Code of Conduct. 
+The project has made a number of improvements to the governance based on our feedback from January, including the addition of a [contributor ladder](https://github.com/cilium/community/blob/f1ac4d702eadafd8f2cd4aeb66a1e9884847220a/CONTRIBUTOR-LADDER.md), improvements to the [roadmap process](https://docs.cilium.io/en/stable/community/roadmap/#influencing-the-roadmap), and links from the governance documents to the Code of Conduct. 
 
 
 #### Governance Discovery Completeness
@@ -70,16 +70,16 @@ The following table details the governance areas expected for a project. Coverag
 
 | Governance Area | Coverage | Documents | Finding Notes |
 |:----------------|:--------:|:------:|:--------------|
-| Project Purpose | Complete | [Documentation](https://docs.cilium.io/en/latest/overview/intro/) and [README](https://github.com/cilium/cilium/blob/main/README.rst) | |
-| Maintainer List | Complete | [MAINTAINERS.md](https://github.com/cilium/cilium/blob/main/MAINTAINERS.md) | |
-| Code of Conduct | Complete | [CoC](https://github.com/cilium/cilium/blob/main/CODE_OF_CONDUCT.md) | |
-| Contributor Guide | Complete | [CONTRIBUTING.md](https://github.com/cilium/cilium/blob/main/CONTRIBUTING.md) with pointers to docs | |
-| Contributor Ladder | Complete | [CONTRIBUTOR-LADDER.md](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md) | |
+| Project Purpose | Complete | [Documentation](https://docs.cilium.io/en/latest/overview/intro/) and [README](https://github.com/cilium/cilium/blob/9755ad92421c85f17b1160a7c7188784ce005f88/README.rst) | |
+| Maintainer List | Complete | [MAINTAINERS.md](https://github.com/cilium/cilium/blob/9755ad92421c85f17b1160a7c7188784ce005f88/MAINTAINERS.md) | |
+| Code of Conduct | Complete | [CoC](https://github.com/cilium/cilium/blob/9755ad92421c85f17b1160a7c7188784ce005f88/CODE_OF_CONDUCT.md) | |
+| Contributor Guide | Complete | [CONTRIBUTING.md](https://github.com/cilium/cilium/blob/9755ad92421c85f17b1160a7c7188784ce005f88/CONTRIBUTING.md) with pointers to docs | |
+| Contributor Ladder | Complete | [CONTRIBUTOR-LADDER.md](https://github.com/cilium/community/blob/f1ac4d702eadafd8f2cd4aeb66a1e9884847220a/CONTRIBUTOR-LADDER.md) | |
 | Maintainer Lifecycle | Complete | [Granting and Revoking Accesss](https://docs.cilium.io/en/latest/community/governance/commit_access/#granting-commit-access) | Adding emeritus process when revoking would be helpful  |
 | Decision-making | Complete | [Voting](https://docs.cilium.io/en/latest/community/governance/commit_access/#voting) | |
 | Code and Docs Ownership | Complete | [Code Owners](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#code-owners) | Would be nice to have links that don't 404 for non-org members |
-| Security Reporting and response | Complete | [SECURITY.md](https://github.com/cilium/cilium/blob/main/SECURITY.md) | |
-| Communication and Meetings | Complete | [Meetings & Slack](https://docs.cilium.io/en/stable/community/community/) plus [Other channels](https://github.com/cilium/community/tree/main) | |
+| Security Reporting and response | Complete | [SECURITY.md](https://github.com/cilium/cilium/blob/9755ad92421c85f17b1160a7c7188784ce005f88/SECURITY.md) | |
+| Communication and Meetings | Complete | [Meetings & Slack](https://docs.cilium.io/en/stable/community/community/) plus [Other channels](https://github.com/cilium/community/tree/f1ac4d702eadafd8f2cd4aeb66a1e9884847220a) | |
 
 #### Sub-projects, plugins, and related
 
@@ -172,8 +172,8 @@ Areas of potential future development include:
 
 | Finding Title | Importance | Description | Links | Notes & Impact |
 |:------------- |:----------:|:------------|:------|:---------------|
-| Improve organizational diversity | High | Recruit more active maintainers from outside of Isovalent | [MAINTAINERS.md](https://github.com/cilium/cilium/blob/main/MAINTAINERS.md) | This is the most important area of improvement needed, and it creates significant risk for the project. Since there are 2 active non-Isovalent maintainers, this is not a barrier to graduation |
-| Inactive maintainers | High | Inactive maintainers should be moved to Emeritus | [MAINTAINERS.md](https://github.com/cilium/cilium/blob/main/MAINTAINERS.md) | It is important to remove commit access when maintainers are no longer active in the project | 
+| Improve organizational diversity | High | Recruit more active maintainers from outside of Isovalent | [MAINTAINERS.md](https://github.com/cilium/cilium/blob/9755ad92421c85f17b1160a7c7188784ce005f88/MAINTAINERS.md) | This is the most important area of improvement needed, and it creates significant risk for the project. Since there are 2 active non-Isovalent maintainers, this is not a barrier to graduation |
+| Inactive maintainers | High | Inactive maintainers should be moved to Emeritus | [MAINTAINERS.md](https://github.com/cilium/cilium/blob/9755ad92421c85f17b1160a7c7188784ce005f88/MAINTAINERS.md) | It is important to remove commit access when maintainers are no longer active in the project | 
 | SIG Governance | Medium | Document how SIGs and subprojects relate to project governance | [SIG list](https://docs.cilium.io/en/latest/community/community/#all-sigs) | This is important, but is not a barrier to graduation |
 
 ### Previous Reviews

--- a/governance/assessments/projects/cilium/2023-08-22.md
+++ b/governance/assessments/projects/cilium/2023-08-22.md
@@ -91,7 +91,7 @@ The project includes the following sub-projects, plugins, and other notable divi
 
 ### Operation
 
-A maintainer council is the most common governance structure for CNCF projects because it is the simplest.  However, it looks like Cilium may have outgrown that structure.  You currently have more than 20 listed maintainers / committers, and the project has both SIGs and a few defined major subprojects.  You may want to look at some kind of federated structure, where senior leadership consists of leaders from each of the project subgroups.  Or, alternately, some kind of steering committee.
+A maintainer council is the most common governance structure for CNCF projects because it is the simplest.  However, it looks like Cilium may have outgrown that structure.  The project currently have more than 20 listed maintainers / committers, and has both SIGs and a few defined major subprojects.  Cilium community may want to look at some kind of federated structure, where senior leadership consists of leaders from each of the project subgroups.  Or, alternately, some kind of steering committee.
 
 SIGs and Subprojects: in various places, the Cilium project defines several subprojects, including Hubble.  You’ve also defined six SIGs in the governance documentation, one of which overlaps with a subproject.  However, these SIGs need a great deal more to be a functional governance structure, including defined leadership, more rigorous approval process, specified relationships between subprojects/code and the owning SIGs, and a relationship to overall project management.  Done well, the SIGs would provide a stair-step for contributor advancement.
 

--- a/governance/assessments/projects/cilium/2023-08-22.md
+++ b/governance/assessments/projects/cilium/2023-08-22.md
@@ -1,0 +1,176 @@
+# Governance Review Cilium
+
+What follows is a governance review and assessment for the Cilium project. This review is carried out by members of the Governance Working Group of TAG Contributor Strategy. The review may have been done because of a change in maturity level for the project, at the request of the TOC, or as a request by the project itself. If requested by the project, the review will be provided to the project maintainers. Otherwise, the review will be submitted to the TOC for their follow-up.
+
+Projects may ask TAG Contributor Strategy for assistance in resolving any issues uncovered by the review. The TAG is available via our [slack channel](https://cloud-native.slack.com/archives/CT6CWS1JN), [email](https://lists.cncf.io/g/cncf-tag-contributor-strategy), [GitHub](https://github.com/cncf/tag-contributor-strategy), or by joining our weekly meetings (listed on the [CNCF public calendar](https://www.cncf.io/calendar/)).
+
+## Summary and Assessment
+
+This is a follow up to the [assessment conducted](https://docs.google.com/document/d/1AMlmAxnljXtQPkYpGbULCZaKzsPaeJxk-GNu1HnvIeE/edit) when the project applied for graduation in January 2023.
+
+Status: Mostly Satisfactory. There is one must-fix item listed below and 2 areas for improvement. The biggest governance concerns are related to the overwhelming majority of contributors who work at Isovalent and the very small number of active maintainers who work at other companies. These concerns are detailed in the sections below. 
+
+### Executing the Assessment
+
+Original assessment in January 2023 was conducted by Josh Berkus (Red Hat) and Dawn Foster (VMware). This updated assessment was conducted in July and August 2023 by Dawn Foster (CHAOSS project) and Josh Berkus (Red Hat).
+
+### Must-Fix Items
+
+The following issues have been identified that need to be resolved before Graduation:
+
+* Inactive maintainers should be moved to Emeritus
+
+### Areas for Improvement
+
+Over the next year, the project should work on the following issues to improve its governance, these are considered non-blocking:
+
+* Recruit more active maintainers from outside of Isovalent
+* Document how SIGs and subprojects relate to project governance
+
+## Review
+
+### Governance Description
+
+Cilium is governed by a simple Maintainer Council-style governance, where there are a small group of Committers who perform all governance functions for the project.  This is an extremely common governance structure and satisfactory for a variety of projects.  Cilium was founded by Isovalent, whose staff still form the majority of project contributors.
+
+While the project has a SIG structure as well as specific subprojects such as Hubble and Tetragon, these groups have no defined governance duties or powers.
+
+### Discoverability
+
+#### Governance Location
+
+Governance documentation may be found with [Cilium’s main documentation](https://docs.cilium.io/en/latest/community/governance/). The following parts of Cilium governance are well-defined in this documentation:
+
+* Selection of new committers
+* Committer voting procedures
+* Removal of committers, with the most thoroughness we’ve seen from a project
+* Official project communications channels and meetings
+* PR approval process
+* Documentation standards
+
+In general, the definitions and activities of the committers and would-be committers are very well defined.
+
+The project has made a number of improvements to the governance based on our feedback from January, including the addition of a [contributor ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md), improvements to the [roadmap process](https://docs.cilium.io/en/stable/community/roadmap/#influencing-the-roadmap), and links from the governance documents to the Code of Conduct. 
+
+
+#### Governance Discovery Completeness
+
+Governance documentation may be found with [Cilium’s main documentation](https://docs.cilium.io/en/latest/community/governance/), an easy access approach that makes the docs findable for potential contributors. 
+
+While the project has added a contributor ladder and improved the roadmap process, linking to these documents from within the governance section of the documentation would make them easier for people to find.
+
+### Documentation Content
+
+The following table details the governance areas expected for a project. Coverage is indicated by Complete, Partial, and Missing.
+* Complete - the content of the governance documentation is fully detailed and does not leave any question to the reader.
+* Partial - the content of the governance documentation is missing some information and would leave the reader with questions or some level of misunderstanding.
+* Missing - the documentation is absent, wholly undiscoverable, or woefully inadequate in meeting the objectives of that governance content. The reader cannot act on the content that is available.
+* Unknown - status cannot be assessed at this time
+
+| Governance Area | Coverage | Documents | Finding Notes |
+|:----------------|:--------:|:------:|:--------------|
+| Project Purpose | Complete | [Documentation](https://docs.cilium.io/en/latest/overview/intro/) and [README](https://github.com/cilium/cilium/blob/main/README.rst) | |
+| Maintainer List | Complete | [MAINTAINERS.md](https://github.com/cilium/cilium/blob/main/MAINTAINERS.md) | |
+| Code of Conduct | Complete | [CoC](https://github.com/cilium/cilium/blob/main/CODE_OF_CONDUCT.md) | |
+| Contributor Guide | Complete | [CONTRIBUTING.md](https://github.com/cilium/cilium/blob/main/CONTRIBUTING.md) with pointers to docs | |
+| Contributor Ladder | Complete | [CONTRIBUTOR-LADDER.md](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md) | |
+| Maintainer Lifecycle | Complete | [Granting and Revoking Accesss](https://docs.cilium.io/en/latest/community/governance/commit_access/#granting-commit-access) | Adding emeritus process when revoking would be helpful  |
+| Decision-making | Complete | [Voting](https://docs.cilium.io/en/latest/community/governance/commit_access/#voting) | |
+| Code and Docs Ownership | Complete | [Code Owners](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#code-owners) | Would be nice to have links that don't 404 for non-org members |
+| Security Reporting and response | Complete | [SECURITY.md](https://github.com/cilium/cilium/blob/main/SECURITY.md) | |
+| Communication and Meetings | Complete | [Meetings & Slack](https://docs.cilium.io/en/stable/community/community/) plus [Other channels](https://github.com/cilium/community/tree/main) | |
+
+#### Sub-projects, plugins, and related
+
+The project includes the following sub-projects, plugins, and other notable divisions:
+
+| Area | Ownership and Operation | Standing Bodies | Project Alignment | Notes |
+|:-----|:-----------------------:|:---------------:|:------------------|:---|
+|[SIGs](https://docs.cilium.io/en/stable/community/community/#all-sigs)| Partial | Partial | Partial | There is documentation about how to create a SIG, but no information about how they fit into the broader governance. One SIG (Hubble) may overlap with other parts of the project. It ins't clear how work happens within these SIGs  |
+
+### Operation
+
+A maintainer council is the most common governance structure for CNCF projects because it is the simplest.  However, it looks like Cilium may have outgrown that structure.  You currently have more than 20 listed maintainers / committers, and the project has both SIGs and a few defined major subprojects.  You may want to look at some kind of federated structure, where senior leadership consists of leaders from each of the project subgroups.  Or, alternately, some kind of steering committee.
+
+SIGs and Subprojects: in various places, the Cilium project defines several subprojects, including Hubble.  You’ve also defined six SIGs in the governance documentation, one of which overlaps with a subproject.  However, these SIGs need a great deal more to be a functional governance structure, including defined leadership, more rigorous approval process, specified relationships between subprojects/code and the owning SIGs, and a relationship to overall project management.  Done well, the SIGs would provide a stair-step for contributor advancement.
+
+Approving New Committers: the process of approving new committers has one peculiar feature: 
+“To be granted commit access the candidate must receive yes votes from a majority of the existing committers and zero no votes. Since a no vote is effectively a veto of the candidate it should be accompanied by a reason for the vote.”
+This is not something we’ve encountered in other projects; can Cilium explain the reason for this rule?  It makes it considerably more difficult to approve a new committer than to remove one, and provides opportunities for a single committer to be extremely disruptive.  What was that rule in response to?
+
+Voting History and Transparency: currently all votes take place on Slack, presumably with the aid of vote-counting automation.  This raises a some questions about community access to decision making.  First, is the #committers channel open or closed, and can other community members see decisions taking place?  Second, where are votes recorded for posterity, given that Slack history is not really archival?
+
+#### Transparency and freshness
+
+Transparency for a project is exemplified in the public documentation, record, and communications, allowing observers and contributors to monitor the project's adherence to their stated governance. Freshness indicates governance activities mirror the documented governance for the project, and have been reviewed or updated recently.
+
+The project's governance documentation and activities are transparent and up to date.
+
+#### Governance Drift
+
+Governance Drift can occur when the executed and observable governance of a project deviates from the documented governance of the project.
+
+The project has regular community meetings on a variety of topics with a variety of hosts, upholding their written governance structures. It is too early to say if they have governance drift, as most of their written governance was recently adopted.
+
+#### Ownership
+
+Ownership audit has not been conducted, as the CNCF is not yet ready to provide this fucntionality.
+
+### Maintainer List(s)
+
+The project's maintainer list(s) is partially current. Individuals on the maintainer list do appear to match the requirements of maintainership in accordance with the project's documented requirements. The maintainer affiliations (employers) reflect Unbalanced diversity with most of the maintainers working for Isovalent; however, there are a few active maintainers who work for other organizations.
+
+There are a large number of committers listed in the MAINTAINERS.md file, which shows that quite a few people are engaged in the project on a regular basis, including some non-Isovalent contributors listed as committers. However, some of the committers are inactive and might be removed. Of particular concern is that none of the non-Isovalent committers listed in the MAINTAINERS.md file are continuing to make significant numbers of contributions to the project, and many of them are contributing much less than they were in the previous 3 quarters (with the caveat that the data comes from devstats, which excludes non-code contributions that these people may be making).
+
+* Eloy Coto (Red Hat): hasn’t contributed in the past year.  Verified that they are no longer working on Cillium.
+* Deepesh Pathak: has made no contributions in the past year.
+* Hemanth Malla (Datadog): is one of the more active non-Isovalent contributors, but has still made only 14 contributions in the past quarter (63 contributions in the past year). 
+* Ian Vernon: has made no contributions in the past quarter (2 contributions in the past year).
+* Laurent Bernaille (Datadog): has made no contributions in the past quarter (3 contributions in the past year).
+* Michal Rostecki (Deepfence): hasn’t contributed in the past year.
+* Nirmoy Das (AMD): hasn’t contributed in the past year.
+* Vlad Ungureanu: has made only 3 contribution in the past quarter (5 contributions in the past year).
+* Weilong Cui (Google): has made no contributions in the past quarter (30 contributions in the past year).
+* Yongkun Gui (Google): has made only 7 contributions in the past quarter (34 contributions in the past year), which is a slight increase since the last review.
+
+Most non-Isovalent maintainers (with the exception of Yongkun and Hemanth) have contributed less this quarter / year than when we did the original assessment in January, and there have been no new non-Isovalent maintainers added to the list. The decline in non-Isovalent maintainers feels like a problem that needs to be addressed urgently.
+
+For these maintainers in particular, Cilium should verify activity status, and document any whose main contribution is non-code (and thus not appearing in Devstats). While we appreciate the move of a few maintainers to the Emeritus list, the project still needs to retire more of the inactive committers, and given the voting system, the project could be forced to reboot governance due to unability to get a majority.
+
+The TOC requires maintainers from more than one company for two reasons:
+Demonstrating that the project is open to contributors regardless of employer, which Cilium clearly has, and
+Reducing risks that a single employer’s change of status could lead to the project becoming unmaintained, which is the current critical issue.
+Given this, Cilium needs a plan to reactivate/replace some of the non-Isovalent committers.  The recent adoption of a contributor ladder is a great first step toward encouraging ongoing contributor advancement, but there is still more work to do for recruiting new contributors who work outside of Isovalent.
+
+### Evolution
+
+Governance evolution is the observable changes and improvements the project makes to its governance over the project's lifespan. It is expected that changes will occur over the project's life and that such changes are iterative, tested, and adjusted.
+
+Major milestones in the project's governance over time include:
+
+* Addition of a contributor ladder, including roles for both code and non-code contributions
+* Clarification of how roadmap changes are made
+
+Recent changes to the governance include:
+
+* Links to Code of Conduct from governance
+* Moving a few inactive maintainers to Emeritus
+
+Areas of potential future development include:
+
+* Figure out and document how SIGs and subprojects relate to project governance
+
+### Governance Findings Table
+
+| Finding Title | Importance | Description | Links | Notes & Impact |
+|:------------- |:----------:|:------------|:------|:---------------|
+| Improve organizational diversity | High | Recruit more active maintainers from outside of Isovalent | [MAINTAINERS.md](https://github.com/cilium/cilium/blob/main/MAINTAINERS.md) | This is the most important area of improvement needed, and it creates significant risk for the project. Since there are 2 active non-Isovalent maintainers, this is not a barrier to graduation |
+| Inactive maintainers | High | Inactive maintainers should be moved to Emeritus | [MAINTAINERS.md](https://github.com/cilium/cilium/blob/main/MAINTAINERS.md) | It is important to remove commit access when maintainers are no longer active in the project | 
+| SIG Governance | Medium | Document how SIGs and subprojects relate to project governance | [SIG list](https://docs.cilium.io/en/latest/community/community/#all-sigs) | This is important, but is not a barrier to graduation |
+
+### Previous Reviews
+
+| Date   | Requested By  |                   Reason                   | Link                 |
+|:-------|:--------------|:------------------------------------------:|:---------------------|
+| January 2023 | Project | Maturity change | [Review](https://docs.google.com/document/d/1AMlmAxnljXtQPkYpGbULCZaKzsPaeJxk-GNu1HnvIeE/edit) |
+

--- a/governance/assessments/projects/cilium/2023-08-22.md
+++ b/governance/assessments/projects/cilium/2023-08-22.md
@@ -141,7 +141,7 @@ Most non-Isovalent maintainers (with the exception of Yongkun and Hemanth) have 
 For these maintainers in particular, Cilium should verify activity status, and document any whose main contribution is non-code (and thus not appearing in Devstats). While we appreciate the move of a few maintainers to the Emeritus list, the project still could move other inactive committers into an Emeritus role. This is important for a few reasons:
 
 * Given the voting system, the project could be forced to reboot governance due to inability to get a majority. With so many inactive maintainers, it could become difficult or impossible to achieve a majority when voting if people are no longer active in the project. This could delay critical work or cause other disruption within the project.
-* For security reasons, inactive maintainers should have their elevated access within the project removed so that only the people who need elevated access for active maintainer duties have it.
+* Inactive accounts with maintainer privileges on projects are attractive targets for attackers looking to introduce vulnerable code to projects in use by adopters. With the increase in software supply chain attacks, clearly defining and proactively managing maintainer activity may reduce the likelihood of an inactive account being taken over.
 
 Keep in mind that these people are still part of the community and can continue to contribute. By moving them to Emeritus, they are only being relieved of their maintainer obligations (including voting), but are not being removed from the project or the community. If they should desire to become more involved in the future, they can be moved from Emeritus back into a maintainer role.
 


### PR DESCRIPTION
This is a draft of the Cilium project governance review primarily for TOC feedback at this point while we finalize a few details. 

Overall, the governance structure for Cilium is pretty solid, and they have made some good progress in updating their governance to address some of our concerns from the original [governance review in January 2023](https://docs.google.com/document/d/1AMlmAxnljXtQPkYpGbULCZaKzsPaeJxk-GNu1HnvIeE/edit).

However, we still have concerns about maintainers and participation from contributors who work outside of Isovalent. In particular, there are a few concerns that we want feedback from our TOC liaisons @TheFoxAtWork @dzolotusky and @kgamanji as one of the people leading the graduation DD:
* In our original review we asked them to update the list of maintainers because most of the non-Isovalent maintainers were not active. Looking at the maintainers list in this review and comparing it to the original from January, we still see mostly the same list of inactive maintainers.
* There are 2 maintainers who are still active who work at other companies, but their activity is minimal, so we're not sure that this meets the spirit of the requirement to have maintainers from multiple companies.
* 8 of the 10 people on the maintainers list from the January review are no longer active in the project, which raises a bigger concern about **why** so many of the maintainers from other companies have decreased their contributions and become inactive? This may simply be because people's jobs have changed (we know this is the case for one individual), but this feels like something we need to better understand.

@jberkus - did I miss anything?

The intent is to get guidance from the TOC about these concerns before finalizing the review.