### PR TITLE
First iteration of governance self assessment guide

### DIFF
--- a/website/content/maintainers/governance/governance-self-assessment-template.md
+++ b/website/content/maintainers/governance/governance-self-assessment-template.md
@@ -19,20 +19,6 @@ Date of the assessment: [TODO]
 
 Executors: [TODO]
 
-# Governance Review Template
-
-Governance reviews contribute to the health and sustainibility of the CNCF projects. By providing guidance on 
-effective governance practices, TAG Contributor Strategy aims to ensure that projects operate efficiently, 
-encourage diverse participation, and uphold the values of the CNCF. The governance review process is designed to be 
-constructive and supportive, aiming to assist projects in refining their governance models and addressing 
-any challenges they may face.
-
-Projects may ask TAG Contributor Strategy for assistance in resolving any issues uncovered by the review. The TAG is 
-available via our [slack channel](https://cloud-native.slack.com/archives/CT6CWS1JN), 
-[email](https://lists.cncf.io/g/cncf-tag-contributor-strategy), 
-[GitHub](https://github.com/cncf/tag-contributor-strategy), or by joining our weekly meetings 
-(listed on the [CNCF public calendar](https://www.cncf.io/calendar/)).
-
 ## Summary and Assessment
 
 Status: [TODO: Exemplary|Satisfactory|Mostly Satisfactory|Needs Work]

--- a/website/content/maintainers/governance/governance-self-assessment-template.md
+++ b/website/content/maintainers/governance/governance-self-assessment-template.md
@@ -8,9 +8,10 @@ weight: 50
 
 Please see the [Governance Self Assessment Guide](/maintainers/governance/governance-self-assessment/) for the instructions.
 
-## Governance Self Assessment Template
+## Template
 
-### Project Information
+```markdown
+# Project Information
 
 Project Name: [TODO]
 
@@ -20,9 +21,17 @@ Executors: [TODO]
 
 # Governance Review Template
 
-Governance reviews contribute to the health and sustainibility of the CNCF projects. By providing guidance on effective governance practices, TAG Contributor Strategy aims to ensure that projects operate efficiently, encourage diverse participation, and uphold the values of the CNCF. The governance review process is designed to be constructive and supportive, aiming to assist projects in refining their governance models and addressing any challenges they may face.
+Governance reviews contribute to the health and sustainibility of the CNCF projects. By providing guidance on 
+effective governance practices, TAG Contributor Strategy aims to ensure that projects operate efficiently, 
+encourage diverse participation, and uphold the values of the CNCF. The governance review process is designed to be 
+constructive and supportive, aiming to assist projects in refining their governance models and addressing 
+any challenges they may face.
 
-Projects may ask TAG Contributor Strategy for assistance in resolving any issues uncovered by the review. The TAG is available via our [slack channel](https://cloud-native.slack.com/archives/CT6CWS1JN), [email](https://lists.cncf.io/g/cncf-tag-contributor-strategy), [GitHub](https://github.com/cncf/tag-contributor-strategy), or by joining our weekly meetings (listed on the [CNCF public calendar](https://www.cncf.io/calendar/)).
+Projects may ask TAG Contributor Strategy for assistance in resolving any issues uncovered by the review. The TAG is 
+available via our [slack channel](https://cloud-native.slack.com/archives/CT6CWS1JN), 
+[email](https://lists.cncf.io/g/cncf-tag-contributor-strategy), 
+[GitHub](https://github.com/cncf/tag-contributor-strategy), or by joining our weekly meetings 
+(listed on the [CNCF public calendar](https://www.cncf.io/calendar/)).
 
 ## Summary and Assessment
 
@@ -72,24 +81,27 @@ Details of these issues can be found in the [Findings Table](#Governance-Finding
 
 ### Documentation Content
 
-The following table details the governance areas expected for a project. Coverage is indicated by Complete, Partial, Missing, and Unknown.
+The following table details the governance areas expected for a project. Coverage is indicated by Complete, Partial, 
+Missing, and Unknown.
 * Complete - the content of the governance documentation is fully detailed and does not leave any question to the reader.
-* Partial - the content of the governance documentation is missing some information and would leave the reader with questions or some level of misunderstanding.
-* Missing - the documentation is absent, wholly undiscoverable, or woefully inadequate in meeting the objectives of that governance content. The reader cannot act on the content that is available.
+* Partial - the content of the governance documentation is missing some information and would leave the reader 
+  with questions or some level of misunderstanding.
+* Missing - the documentation is absent, wholly undiscoverable, or woefully inadequate in meeting the objectives 
+  of that governance content. The reader cannot act on the content that is available.
 * Unknown - status cannot be assessed at this time
 
-| Governance Area |                 Coverage                 | Documents | Finding Notes |
-|:----------------|:----------------------------------------:|:---------:|:--------------|
-| Project Purpose |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]        |
-| Maintainer List |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]        |
-| Code of Conduct |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
-| Contributor Guide |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
-| Contributor Ladder |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
-| Maintainer Lifecycle |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
-| Decision-making |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
-| Code and Docs Ownership |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
-| Security Reporting and response | [TODO: Complete/Partial/Missing/Unknown] |  [TODO: LINKS]  | [TODO]              |
-| Communication and Meetings | [TODO: Complete/Partial/Missing/Unknown] |  [TODO: LINKS]  | [TODO]              |
+| Governance Area                 |                 Coverage                 |   Documents   | Finding Notes |
+|:--------------------------------|:----------------------------------------:|:-------------:|:--------------|
+| Project Purpose                 | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
+| Maintainer List                 | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
+| Code of Conduct                 | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
+| Contributor Guide               | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
+| Contributor Ladder              | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
+| Maintainer Lifecycle            | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
+| Decision-making                 | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
+| Code and Docs Ownership         | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
+| Security Reporting and response | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
+| Communication and Meetings      | [TODO: Complete/Partial/Missing/Unknown] | [TODO: LINKS] | [TODO]        |
 
 
 
@@ -97,8 +109,8 @@ The following table details the governance areas expected for a project. Coverag
 
 The project includes the following sub-projects, plugins, and other notable divisions:
 
-| Area          |  Ownership and Operation   |     Standing Bodies      | Project Alignment           | Notes  |
-|:--------------|:--------------------------:|:------------------------:|:----------------------------|:-------|
+| Area                |     Ownership and Operation      |        Standing Bodies         | Project Alignment                 | Notes  |
+|:--------------------|:--------------------------------:|:------------------------------:|:----------------------------------|:-------|
 | [TODO: sub-project] | [TODO: Complete/Partial/Missing] | [TODO: Complete/Partial/Other] | [TODO: Complete/Partial/Conflict] | [TODO] |
 
 ### Operation
@@ -107,13 +119,17 @@ The project includes the following sub-projects, plugins, and other notable divi
 
 #### Transparency and freshness
 
-Transparency for a project is exemplified in the public documentation, record, and communications, allowing observers and contributors to monitor the project's adherence to their stated governance. Freshness indicates governance activities mirror the documented governance for the project, and have been reviewed or updated recently.
+Transparency for a project is exemplified in the public documentation, record, and communications, allowing observers 
+and contributors to monitor the project's adherence to their stated governance.
+Freshness indicates governance activities mirror the documented governance for the project, and have been reviewed 
+or updated recently.
 
 The project's governance documentation and activities are [TODO]
 
 #### Governance Drift
 
-Governance Drift can occur when the executed and observable governance of a project deviates from the documented governance of the project.
+Governance Drift can occur when the executed and observable governance of a project deviates from the documented 
+governance of the project.
 
 The project [TODO: does/does] not experience governance drift as indicated by [TODO]...
 
@@ -121,15 +137,21 @@ The project [TODO: does/does] not experience governance drift as indicated by [T
 
 The project's ownership evaluation [TODO: did/did not] leverage Sheriff, the CNCF GitHub permission auditing tool.
 
-The project's permissions and ownership settings and files [TODO: are/are not] appropriate for the stated governance. Specifically, [TODO]...
+The project's permissions and ownership settings and files [TODO: are/are not] appropriate for the stated governance.
+Specifically, [TODO]...
 
 ### Maintainer List(s)
 
-The project's maintainer list(s) [TODO: are/are not] current. Individuals on the maintainer list [TODO: do/do not] appear to match the requirements of maintainership in accordance with the project's documented requirements. The maintainer affiliations (employers) reflect [TODO: Balanced/Unbalanced] diversity.
+The project's maintainer list(s) [TODO: are/are not] current.
+Individuals on the maintainer list [TODO: do/do not] appear to match the requirements of maintainership in accordance 
+with the project's documented requirements. 
+The maintainer affiliations (employers) reflect [TODO: Balanced/Unbalanced] diversity.
 
 ### Evolution
 
-Governance evolution is the observable changes and improvements the project makes to its governance over the project's lifespan. It is expected that changes will occur over the project's life and that such changes are iterative, tested, and adjusted.
+Governance evolution is the observable changes and improvements the project makes to its governance over the 
+project's lifespan.
+It is expected that changes will occur over the project's life and that such changes are iterative, tested, and adjusted.
 
 Major milestones in the project's governance over time include:
 
@@ -154,3 +176,5 @@ Areas of potential future development include:
 | Date         | Requested By       |                     Reason                      | Link                      |
 |:-------------|:-------------------|:-----------------------------------------------:|:--------------------------|
 | [TODO:Date*] | [TODO:TOC/Project] | [TODO:Maturity change / project request / etc.] | [TODO:link to review doc] |
+
+```

--- a/website/content/maintainers/governance/governance-self-assessment-template.md
+++ b/website/content/maintainers/governance/governance-self-assessment-template.md
@@ -131,9 +131,7 @@ Areas of potential future development include:
 |:--------------|:-------------------------------:|:----------------------------|:----------------------|:-----------------------------------------------------------------|
 | [TODO: Title] | [TODO:Critical/High/Medium/Low] | [TODO:detailed description] | [TODO:relevant links] | [TODO:additional notes and explanation of impact if appropriate] |
 
-### Points of Excellence
-
-The following aspects of governance are exemplary, and can be referenced as examples for other projects to copy:
+##### Improvements made since assessment start
 
 * [TODO]
 

--- a/website/content/maintainers/governance/governance-self-assessment-template.md
+++ b/website/content/maintainers/governance/governance-self-assessment-template.md
@@ -19,35 +19,9 @@ Date of the assessment: [TODO]
 
 Executors: [TODO]
 
-## Summary and Assessment
-
-Status: [TODO: Exemplary|Satisfactory|Mostly Satisfactory|Needs Work]
-
 ### Executing the Assessment
 
 [TODO]
-
-### Must-Fix Items
-
-Items in the "Governance Findings Table" at the bottom with "Critical" importance are reported here as must-fix items.
-
-The following issues have been identified that need to be resolved before [TODO: project milestone | other requirement]:
-
-* [TODO]
-
-### Points of Excellence
-
-The following aspects of governance are exemplary, and can be referenced as examples for other projects to copy:
-
-* [TODO]
-
-### Areas for Improvement
-
-Over the next year, the project should work on the following issues to improve its governance, these are considered non-blocking:
-
-* [TODO]
-
-Details of these issues can be found in the [Findings Table](#Governance-Findings-Table) and the related sections below.
 
 ## Review
 
@@ -156,6 +130,12 @@ Areas of potential future development include:
 | Finding Title |           Importance            | Description                 | Links                 | Notes & Impact                                                   |
 |:--------------|:-------------------------------:|:----------------------------|:----------------------|:-----------------------------------------------------------------|
 | [TODO: Title] | [TODO:Critical/High/Medium/Low] | [TODO:detailed description] | [TODO:relevant links] | [TODO:additional notes and explanation of impact if appropriate] |
+
+### Points of Excellence
+
+The following aspects of governance are exemplary, and can be referenced as examples for other projects to copy:
+
+* [TODO]
 
 ### Previous Reviews
 

--- a/website/content/maintainers/governance/governance-self-assessment-template.md
+++ b/website/content/maintainers/governance/governance-self-assessment-template.md
@@ -1,0 +1,156 @@
+---
+title: "Self Assessment Template"
+date: 2023-09-15
+weight: 50
+---
+
+## Introduction
+
+Please see the [Governance Self Assessment Guide](/maintainers/governance/governance-self-assessment/) for the instructions.
+
+## Governance Self Assessment Template
+
+### Project Information
+
+Project Name: [TODO]
+
+Date of the assessment: [TODO]
+
+Executors: [TODO]
+
+# Governance Review Template
+
+Governance reviews contribute to the health and sustainibility of the CNCF projects. By providing guidance on effective governance practices, TAG Contributor Strategy aims to ensure that projects operate efficiently, encourage diverse participation, and uphold the values of the CNCF. The governance review process is designed to be constructive and supportive, aiming to assist projects in refining their governance models and addressing any challenges they may face.
+
+Projects may ask TAG Contributor Strategy for assistance in resolving any issues uncovered by the review. The TAG is available via our [slack channel](https://cloud-native.slack.com/archives/CT6CWS1JN), [email](https://lists.cncf.io/g/cncf-tag-contributor-strategy), [GitHub](https://github.com/cncf/tag-contributor-strategy), or by joining our weekly meetings (listed on the [CNCF public calendar](https://www.cncf.io/calendar/)).
+
+## Summary and Assessment
+
+Status: [TODO: Exemplary|Satisfactory|Mostly Satisfactory|Needs Work]
+
+### Executing the Assessment
+
+[TODO]
+
+### Must-Fix Items
+
+Items in the "Governance Findings Table" at the bottom with "Critical" importance are reported here as must-fix items.
+
+The following issues have been identified that need to be resolved before [TODO: project milestone | other requirement]:
+
+* [TODO]
+
+### Points of Excellence
+
+The following aspects of governance are exemplary, and can be referenced as examples for other projects to copy:
+
+* [TODO]
+
+### Areas for Improvement
+
+Over the next year, the project should work on the following issues to improve its governance, these are considered non-blocking:
+
+* [TODO]
+
+Details of these issues can be found in the [Findings Table](#Governance-Findings-Table) and the related sections below.
+
+## Review
+
+### Governance Description
+
+[TODO]
+
+### Discoverability
+
+#### Governance Location
+
+[TODO]
+
+#### Governance Discovery Completeness
+
+[TODO]
+
+### Documentation Content
+
+The following table details the governance areas expected for a project. Coverage is indicated by Complete, Partial, Missing, and Unknown.
+* Complete - the content of the governance documentation is fully detailed and does not leave any question to the reader.
+* Partial - the content of the governance documentation is missing some information and would leave the reader with questions or some level of misunderstanding.
+* Missing - the documentation is absent, wholly undiscoverable, or woefully inadequate in meeting the objectives of that governance content. The reader cannot act on the content that is available.
+* Unknown - status cannot be assessed at this time
+
+| Governance Area |                 Coverage                 | Documents | Finding Notes |
+|:----------------|:----------------------------------------:|:---------:|:--------------|
+| Project Purpose |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]        |
+| Maintainer List |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]        |
+| Code of Conduct |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
+| Contributor Guide |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
+| Contributor Ladder |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
+| Maintainer Lifecycle |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
+| Decision-making |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
+| Code and Docs Ownership |    [TODO: Complete/Partial/Missing/Unknown]    |  [TODO: LINKS]  | [TODO]              |
+| Security Reporting and response | [TODO: Complete/Partial/Missing/Unknown] |  [TODO: LINKS]  | [TODO]              |
+| Communication and Meetings | [TODO: Complete/Partial/Missing/Unknown] |  [TODO: LINKS]  | [TODO]              |
+
+
+
+#### Sub-projects, plugins, and related
+
+The project includes the following sub-projects, plugins, and other notable divisions:
+
+| Area          |  Ownership and Operation   |     Standing Bodies      | Project Alignment           | Notes  |
+|:--------------|:--------------------------:|:------------------------:|:----------------------------|:-------|
+| [TODO: sub-project] | [TODO: Complete/Partial/Missing] | [TODO: Complete/Partial/Other] | [TODO: Complete/Partial/Conflict] | [TODO] |
+
+### Operation
+
+[TODO]
+
+#### Transparency and freshness
+
+Transparency for a project is exemplified in the public documentation, record, and communications, allowing observers and contributors to monitor the project's adherence to their stated governance. Freshness indicates governance activities mirror the documented governance for the project, and have been reviewed or updated recently.
+
+The project's governance documentation and activities are [TODO]
+
+#### Governance Drift
+
+Governance Drift can occur when the executed and observable governance of a project deviates from the documented governance of the project.
+
+The project [TODO: does/does] not experience governance drift as indicated by [TODO]...
+
+#### Ownership
+
+The project's ownership evaluation [TODO: did/did not] leverage Sheriff, the CNCF GitHub permission auditing tool.
+
+The project's permissions and ownership settings and files [TODO: are/are not] appropriate for the stated governance. Specifically, [TODO]...
+
+### Maintainer List(s)
+
+The project's maintainer list(s) [TODO: are/are not] current. Individuals on the maintainer list [TODO: do/do not] appear to match the requirements of maintainership in accordance with the project's documented requirements. The maintainer affiliations (employers) reflect [TODO: Balanced/Unbalanced] diversity.
+
+### Evolution
+
+Governance evolution is the observable changes and improvements the project makes to its governance over the project's lifespan. It is expected that changes will occur over the project's life and that such changes are iterative, tested, and adjusted.
+
+Major milestones in the project's governance over time include:
+
+* [TODO]
+
+Recent changes to the governance include:
+
+* [TODO]
+
+Areas of potential future development include:
+
+* [TODO]
+
+### Governance Findings Table
+
+| Finding Title |           Importance            | Description                 | Links                 | Notes & Impact                                                   |
+|:--------------|:-------------------------------:|:----------------------------|:----------------------|:-----------------------------------------------------------------|
+| [TODO: Title] | [TODO:Critical/High/Medium/Low] | [TODO:detailed description] | [TODO:relevant links] | [TODO:additional notes and explanation of impact if appropriate] |
+
+### Previous Reviews
+
+| Date         | Requested By       |                     Reason                      | Link                      |
+|:-------------|:-------------------|:-----------------------------------------------:|:--------------------------|
+| [TODO:Date*] | [TODO:TOC/Project] | [TODO:Maturity change / project request / etc.] | [TODO:link to review doc] |

--- a/website/content/maintainers/governance/governance-self-assessment.md
+++ b/website/content/maintainers/governance/governance-self-assessment.md
@@ -1,0 +1,242 @@
+---
+title: "Governance Self Assessment"
+date: 2023-09-15
+weight: 40
+---
+
+Governance reviews contribute to the health and sustainibility of the CNCF projects. By providing guidance on
+effective governance practices, TAG Contributor Strategy aims to ensure that projects operate efficiently,
+encourage diverse participation, and uphold the values of the CNCF. The governance review process is designed to be
+constructive and supportive, aiming to assist projects in refining their governance models and addressing
+any challenges they may face.
+
+Projects may ask TAG Contributor Strategy for assistance in resolving any issues uncovered by the review. The TAG is
+available via our [slack channel](https://cloud-native.slack.com/archives/CT6CWS1JN),
+[email](https://lists.cncf.io/g/cncf-tag-contributor-strategy),
+[GitHub](https://github.com/cncf/tag-contributor-strategy), or by joining our weekly meetings
+(listed on the [CNCF public calendar](https://www.cncf.io/calendar/)).
+
+
+TODO: LATER: How to request a TAG CS governance review?
+
+## General Instructions
+Instructions:
+- Copy and paste the template in [Self Assessment Template](governance-self-assessment-template.md) into your favorite editor.
+- Fill in the template with the information about your project. The `TODO` placeholders in the template are there to help you.
+- Pick the latest state of the governance document and use the same point-in-time reference (e.g. commit) for your assessment. If governance consists of multiple documents, make sure you use the same commit.
+    - TODO: what about websites?
+- Make sure all links in your report are permanent links (e.g. with commit hashes).
+- To ensure consistency, use the same commits as links for multiple files within a single repository.
+- It is recommended to start filling this template from the "Review" section. Once you fill everything there, go back to "Summary and Assessment" to summarize the content you wrote.
+    - TODO: do we even need a "Summary and Assessment" section for self-assessments?
+
+## Template details
+
+### Project Information
+
+Fill in the blanks in this section.
+
+#### Summary and Assessment
+
+> **_NOTE:_** Fill this part as a summary of your review. It is recommended to start from the "Review" section below
+> in the template, and then write a summary here.
+
+* Write a final assessment status of one of the below:
+    * Exemplary: project has an extraordinary level of governance development and implementation, and can be used as an example for other projects
+    * Satisfactory: project has appropriate governance for its maturity level and is following that governance
+    * Mostly Satisfactory: project has mostly appropriate governance, but needs to fix one or two things
+    * Needs Work: project's governance is lacking and inadequate for its current level of maturity, and needs substantial work to overcome that
+* Write a short paragraph summarizing the general state of project governance.
+* In the event the project governance requires attention, notify the TOC liaison for their awareness.
+
+##### Executing the Assessment
+
+* Write a brief description that details the timebox the assessment occurred and the individuals involved in the assessment.
+* The description should contain the reason for the assessment.
+
+> **_NOTE:_** Make sure you use a snapshot of the governance documents for your assessment and note the commit hash of the snapshot here as a link.
+
+##### Must-Fix Items
+
+* The items in the list should be summarized, have a prioritized ordering and are expected to be considered blockers to project advancement.
+* Items in the "Governance Findings Table" at the bottom with "Critical" importance should be reported here as must-fix items.
+* For each item in this list, a corresponding detailed description should be placed in the Findings table.
+* Note that which items are required depends on the project's maturity level.
+* If there are no must-fix items, do not delete the section but write that there are no must-fix items.
+
+##### Points of Excellence
+
+* Write a list of governance aspects where the project is exceeding expectations, or any novelty in the approach to governance.
+
+##### Areas for Improvement
+
+* Write a summarized listing of longer term improvement areas for the project.
+* Items in the "Governance Findings Table" at the bottom except the "Critical" importance should be reported here.
+* These items are strongly encouraged but not required for the project's maturity level.
+* Make sure fully detailed descriptions are found in the Finding Table later in the template.
+* Items listed here should be in priority ordering.
+
+#### Review
+
+##### Governance Description
+
+* Write a narrative describing
+    * governance type of the project
+    * number of substantial contributors and their grouped employer affiliations
+    * some general information about its leadership
+    * the project's general status and maturity
+* If the project has any unusual aspects to its governance, describe them here.
+* Link to the project's existing documents where applicable.
+
+> **_NOTE:_** If the project is already under CNCF, you can use Devstats to check the number of substantial contributors.
+
+##### Discoverability
+
+###### Governance Location
+
+* Describe where the governance documents are located. Is it in a primary repo, community Repo, somewhere else?
+
+###### Governance Discovery Completeness
+
+* Describe how easy is it for potential contributors to find and read the governance documentation.
+* Is it findable from the project web page?
+* Are governance files named clearly, and interlinked across the projects repos to the primary?
+
+##### Documentation Content
+
+* Fill in the table with the coverage and completeness of the governance area for your project.
+* Fill in the documents column, with the links to the documents relevant to the governance area.
+* Make sure the links are targeting the commit of the file under evaluation as a point-in-time reference to this review.
+* If you have any findings, note them in the "Notes" column.
+
+Project Purpose:
+- Is the project explaining its purpose/mission/scope/values/principles properly?
+- A good example template is https://contribute.cncf.io/maintainers/governance/charter/
+
+Maintainer List:
+- Is there a maintainer list?
+- Does it contain employer affiliations?
+- Does it contain roles and responsibilities? The most basic one should look like the template: https://github.com/cncf/project-template/blob/main/MAINTAINERS.md
+- You do not need to assess things like employer balance here. There is a separate section called "Maintainer List(s)" for that in the document.
+
+Code of Conduct:
+- Is CNCF CoC adopted across the whole project?
+- Is the process of reporting and handling the violations documented and is it complete?
+
+Contributor Guide:
+- Does the governance mention a contributor guide?
+- Is it fresh? (technical contribution guides shall not be assessed part of the govenrnance review)
+
+Contributor Ladder:
+- Does the governance list the criteria to earn a title in the project? The title may depend on the project (maintainer/lead/approver/contributor/etc.).
+- Are there enough roles, including some intermediate ones?
+- Recommended template: https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md
+
+Maintainer Lifecycle:
+- Does the governance doc define when and how a maintainer can be removed/demoted because of inactivity, voluntary stepping down, code of conduct violations?
+- How about emeritus status?
+- Does the replacement maintainer selection make sense? Is the process documented?
+- How about lifecycle for the other roles? (committee members, leads, ...)
+
+Decision-making:
+- Does the governance doc define who the decision makers are?
+- Is the decision making process documented?
+- Is the decision making process consistent and logical?
+
+Code and Docs Ownership:
+- Does the governance doc define who has write/admin access to the code and docs?
+- Only assess if the ownership is documented and if it makes sense. Auditing the permissions is not in the scope of this section.
+
+Security Reporting and response:
+- Is security reporting and response processes documented?
+- Is it in alignment with the guidelines here at minimum https://contribute.cncf.io/maintainers/templates/governance-maintainer/#security-response-team ?
+
+Communication and Meetings:
+- Is project communication channels and meetings documented about when and where they happen?
+
+###### Sub-projects, plugins, and related
+
+* If the project has subprojects, plugins, or other divisions define them here.
+* For each, write if the ownership and operation are clearly described.
+* Are any standing committees/teams fully described, including listing their members?
+* Does it conform to, align, and is it within scope of the governance expectations of the project?
+
+> **_NOTE:_** Assessing if the project has notable divisions as subprojects could be hard. Reach out to a TAG member or TOC liaison in that case.
+
+##### Operation
+
+Review the project repositories, issues, Pull Requests (PRs), documents, videos, and communications to determine
+answers to the following sub-sections.
+
+###### Transparency and freshness
+
+Transparency for a project is exemplified in the public documentation, record, and communications, allowing observers
+and contributors to monitor the project's adherence to their stated governance.
+
+Freshness indicates governance activities mirror the documented governance for the project, and have been reviewed or updated recently.
+
+Answer the following questions in a paragraph:
+* Are governance activities transparent and monitorable?
+* Are the governance documents up to date?
+* Do they accurately reflect current project participants, code and subproject status, etc?
+
+###### Governance Drift
+
+Governance Drift can occur when the executed and observable governance of a project deviates from the documented governance of the project.
+
+Answer the following questions in a paragraph:
+* Are the governance activities being carried out?
+* Are community meetings (if any) happening?
+* Are required elections and votes taking place?
+* Are official communications channels accessible, staffed and responsive?
+* Are they being used?
+* Are questions and proposed updates/changes to governance (if any) being transparently discussed and addressed?
+
+###### Ownership
+
+Not applicable for projects joining the CNCF.
+
+For any CNCF projects:
+* Request that CNCF staff carry out an audit (via Sheriff) that the explicit governance of the
+  project matches GitHub permissions.
+    * Check both that all listed maintainers, owners, and other leaders have the level of ownership or approvership
+      that they are supposed to.
+    * Check that there aren't individuals who have broad permissions that aren't explained by any official project role.
+
+##### Maintainer List(s)
+
+* Check the list of CNCF-level Maintainers for the project.
+* Answer the following question about the project's maintainers:
+    * Are they current?
+    * Are all of the people listed as Maintainers current & frequent contributors to the project, either code or
+      non-code as required by the governance documents?
+    * What's the level of employer diversity in the current list of maintainers?
+    * Are employer affiliations listed in the maintainers list file?
+    * Is there a balance?
+
+> **_NOTE:_** Balance may be achieved through standing bodies, decision making, and other documentation. It should ensure no
+single entity can control the project's direction without informed consensus of other authorized parties.
+
+##### Evolution
+
+Governance evolution is the observable changes and improvements the project makes to its governance over the project's lifespan.
+It is expected that changes will occur over the project's life and that such changes are iterative, tested, and adjusted.
+
+Answer these questions?
+* How has the project's governance evolved over time?
+    * What are the major milestones?
+    * What are the recent changes?
+* Is the project steadily refining/advancing its governance as the project grows and resolves issues?
+* Are there any areas of potential future development?
+
+##### Governance Findings Table
+
+* Add additional rows as necessary.
+* For each finding described above, it should also be included here with further detail.
+* Findings here with "Critical" importance should be reported as "must-fix" in the summary.
+* Findings here with "Medium" and "Low" importance should be reported as "Areas for Improvement" in the summary.
+
+##### Previous Reviews
+
+Fill any previous reviews of the project here, including both the self-assessment and TAG Contributor Strategy reviews.
+If there are none, write that there are no previous reviews.

--- a/website/content/maintainers/governance/governance-self-assessment.md
+++ b/website/content/maintainers/governance/governance-self-assessment.md
@@ -36,45 +36,12 @@ Instructions:
 
 Fill in the blanks in this section.
 
-#### Summary and Assessment
-
-> **_NOTE:_** Fill this part as a summary of your review. It is recommended to start from the "Review" section below
-> in the template, and then write a summary here.
-
-* Write a final assessment status of one of the below:
-    * Exemplary: project has an extraordinary level of governance development and implementation, and can be used as an example for other projects
-    * Satisfactory: project has appropriate governance for its maturity level and is following that governance
-    * Mostly Satisfactory: project has mostly appropriate governance, but needs to fix one or two things
-    * Needs Work: project's governance is lacking and inadequate for its current level of maturity, and needs substantial work to overcome that
-* Write a short paragraph summarizing the general state of project governance.
-* In the event the project governance requires attention, notify the TOC liaison for their awareness.
-
 ##### Executing the Assessment
 
 * Write a brief description that details the timebox the assessment occurred and the individuals involved in the assessment.
 * The description should contain the reason for the assessment.
 
 > **_NOTE:_** Make sure you use a snapshot of the governance documents for your assessment and note the commit hash of the snapshot here as a link.
-
-##### Must-Fix Items
-
-* The items in the list should be summarized, have a prioritized ordering and are expected to be considered blockers to project advancement.
-* Items in the "Governance Findings Table" at the bottom with "Critical" importance should be reported here as must-fix items.
-* For each item in this list, a corresponding detailed description should be placed in the Findings table.
-* Note that which items are required depends on the project's maturity level.
-* If there are no must-fix items, do not delete the section but write that there are no must-fix items.
-
-##### Points of Excellence
-
-* Write a list of governance aspects where the project is exceeding expectations, or any novelty in the approach to governance.
-
-##### Areas for Improvement
-
-* Write a summarized listing of longer term improvement areas for the project.
-* Items in the "Governance Findings Table" at the bottom except the "Critical" importance should be reported here.
-* These items are strongly encouraged but not required for the project's maturity level.
-* Make sure fully detailed descriptions are found in the Finding Table later in the template.
-* Items listed here should be in priority ordering.
 
 #### Review
 
@@ -235,6 +202,10 @@ Answer these questions?
 * For each finding described above, it should also be included here with further detail.
 * Findings here with "Critical" importance should be reported as "must-fix" in the summary.
 * Findings here with "Medium" and "Low" importance should be reported as "Areas for Improvement" in the summary.
+
+##### Points of Excellence
+
+* Write a list of governance aspects where the project is exceeding expectations, or any novelty in the approach to governance.
 
 ##### Previous Reviews
 

--- a/website/content/maintainers/governance/governance-self-assessment.md
+++ b/website/content/maintainers/governance/governance-self-assessment.md
@@ -66,7 +66,7 @@ Fill in the blanks in this section.
 ###### Governance Discovery Completeness
 
 * Describe how easy is it for potential contributors to find and read the governance documentation.
-* Is it findable from the project web page?
+* Is it findable from the project web page and repository README files?
 * Are governance files named clearly, and interlinked across the projects repos to the primary?
 
 ##### Documentation Content

--- a/website/content/maintainers/governance/governance-self-assessment.md
+++ b/website/content/maintainers/governance/governance-self-assessment.md
@@ -65,8 +65,6 @@ Fill in the blanks in this section.
 * If the project has any unusual aspects to its governance, describe them here.
 * Link to the project's existing documents where applicable.
 
-> **_NOTE:_** If the project is already under CNCF, you can use Devstats to check the number of substantial contributors.
-
 ##### Discoverability
 
 ###### Governance Location

--- a/website/content/maintainers/governance/governance-self-assessment.md
+++ b/website/content/maintainers/governance/governance-self-assessment.md
@@ -38,7 +38,7 @@ Fill in the blanks in this section.
 
 ##### Executing the Assessment
 
-* Write a brief description that details the timebox the assessment occurred and the individuals involved in the assessment.
+* Write a brief description that details the timeframe when the assessment occurred and the individuals involved in the assessment.
 * The description should contain the reason for the assessment.
 
 > **_NOTE:_** Make sure you use a snapshot of the governance documents for your assessment and note the commit hash of the snapshot here as a link.

--- a/website/content/maintainers/governance/governance-self-assessment.md
+++ b/website/content/maintainers/governance/governance-self-assessment.md
@@ -39,7 +39,7 @@ Fill in the blanks in this section.
 ##### Executing the Assessment
 
 * Write a brief description that details the timeframe when the assessment occurred and the individuals involved in the assessment.
-* The description should contain the reason for the assessment.
+* The description should contain the reason for the assessment. This is usually when the project is applying to change levels, but could occur at other points.
 
 > **_NOTE:_** Make sure you use a snapshot of the governance documents for your assessment and note the commit hash of the snapshot here as a link.
 

--- a/website/content/maintainers/governance/governance-self-assessment.md
+++ b/website/content/maintainers/governance/governance-self-assessment.md
@@ -19,7 +19,17 @@ available via our [slack channel](https://cloud-native.slack.com/archives/CT6CWS
 
 TODO: LATER: How to request a TAG CS governance review?
 
-## General Instructions
+## General Information
+
+If your project governance was not already based on one of the 
+[CNCF governance templates](/maintainers/templates/governance-intro/), we recommend that you start 
+by looking at those templates to see if one would be suitable for your project. If so, you can update your governance 
+using one of our templates as pre-work before starting this self-assessment. 
+
+It isn't a requirement to use one of our templates, but the templates do have most of the elements that we expect to 
+see in project governance documents, so incorporating any missing elements into your governance is likely to make 
+the assessment process easier.
+
 Instructions:
 - Copy and paste the template in [Self Assessment Template](governance-self-assessment-template.md) into your favorite editor.
 - Fill in the template with the information about your project. The `TODO` placeholders in the template are there to help you.
@@ -49,7 +59,7 @@ Fill in the blanks in this section.
 
 * Write a narrative describing
     * governance type of the project
-    * number of substantial contributors and their grouped employer affiliations
+    * number of maintainers and their grouped employer affiliations
     * some general information about its leadership
     * the project's general status and maturity
 * If the project has any unusual aspects to its governance, describe them here.
@@ -163,12 +173,10 @@ Answer the following questions in a paragraph:
 
 Not applicable for projects joining the CNCF.
 
-For any CNCF projects:
-* Request that CNCF staff carry out an audit (via Sheriff) that the explicit governance of the
-  project matches GitHub permissions.
-    * Check both that all listed maintainers, owners, and other leaders have the level of ownership or approvership
-      that they are supposed to.
-    * Check that there aren't individuals who have broad permissions that aren't explained by any official project role.
+* Check if the explicit governance of the project matches GitHub permissions.
+  * Check both that all listed maintainers, owners, and other leaders have the level of ownership or approvership
+  that they are supposed to.
+  * Check that there aren't individuals who have broad permissions that aren't explained by any official project role.
 
 ##### Maintainer List(s)
 
@@ -203,9 +211,10 @@ Answer these questions?
 * Findings here with "Critical" importance should be reported as "must-fix" in the summary.
 * Findings here with "Medium" and "Low" importance should be reported as "Areas for Improvement" in the summary.
 
-##### Points of Excellence
+##### Improvements made since assessment start
 
-* Write a list of governance aspects where the project is exceeding expectations, or any novelty in the approach to governance.
+If you would like to list some improvements you have made to your project governance from the point where you have 
+started looking at doing the assessment, you can list them here.
 
 ##### Previous Reviews
 


### PR DESCRIPTION
> **_NOTE:_** This PR is opened against a feature branch, [governance-self-assessment-guide](https://github.com/cncf/tag-contributor-strategy/tree/governance-self-assessment-guide). We can work safely here in this branch and eventually merge it to main.

Activities:
* Copy&paste the existing template for TAG members from https://github.com/cncf/tag-contributor-strategy/pull/483
* Replace the content in the template with `TODO`s; remove the instructions
* Create a separate guide document, which gives instructions on how to use the template
* Remove some sections that might not be suitable for a self-assessment that cause self-assessment executors to make a grading: Summary, Assessment (Grade), Must-Fix Items, Areas for improvement. The reason for that is, I believe that it is enough for executors to list findings. TAG can do the grading.
* Move "Points of Excellence" down in the template

Preview:
- https://deploy-preview-520--cncf-contribute.netlify.app/maintainers/governance/governance-self-assessment/
- https://deploy-preview-520--cncf-contribute.netlify.app/maintainers/governance/governance-self-assessment-template/