### PR TITLE
Add non-code label to settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -57,6 +57,8 @@ labels:
     color: C61B7A
   - name: project-level-review
     color: B60205
+  - name: non-code
+    color: c0ffee
 
 # additional colors in this palette:
 # ff69b4


### PR DESCRIPTION
Related to the work started in https://github.com/cncf/tag-contributor-strategy/issues/82
Creating a label for managing Issues and PRs for the Non-Code initiative that would fall under the Contributor Growth WG