### PR TITLE
Updating Mentoring WG Charter: New chairs

### DIFF
--- a/mentoring/README.md
+++ b/mentoring/README.md
@@ -78,6 +78,10 @@ Facilitators:
 ## Chairs
 
 * Nate Waddington (Linux Foundation/CNCF)
+* Ali Ok (Red Hat)
+
+### Emeritus chairs
+
 * Jay Tihema (ii)
 
 ## Tech leads


### PR DESCRIPTION
Jay (@jaytiaki) has decided to step down from being a Mentoring WG co-chair and will move to an emeritus position. I want to thank him for all his work setting up the Mentoring WG and his work with the group since. You've been instrumental, Jay!

Further, I'd like to nominate Ali (@aliok) to fill the co-chair position. Ali has been a CNCF Google Summer of Code administrator and has been a regular contributor to both the Mentoring WG and the TAG Contributor Strategy. He's also been very helpful in the cncf/mentoring community discussion boards. He is someone I go to for advice on mentorship issues generally.

Mentoring WG Charter update: 
* Moving Jay T. to the emeritus chairs section
* Nominating Ali O. as co-chair

I'd like to have opened this discussion at the previous Mentoring WG meeting. Unfortunately, we had to postpone due to (my) confusion around the daylight savings time shift. However, This PR allows us to discuss this change asynchronously.

/cc chairs @geekygirldawn @jberkus @CathPag 
/cc liaisons @TheFoxAtWork @dzolotusky