### PR TITLE
Workaround for showing blank issues in issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Open a blank issue
+    url: https://github.com/cncf/tag-contributor-strategy/issues/new
+    about: Please open a blank issue to if you don't see your issue type here.


### PR DESCRIPTION
Fixes #587

See #587 about the problem.

This PR tries to address that problem by using GitHub's contact links feature.

If this is merged, the issue page (https://github.com/cncf/tag-contributor-strategy/issues/new/choose) will look similar to this:

<img width="1350" alt="Screenshot 2024-01-25 at 09 56 46" src="https://github.com/cncf/tag-contributor-strategy/assets/376732/e615ef0f-abf8-4843-a538-448214df2a1d">
