### PR TITLE
Update Hugo to support Hugo modules

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
   command = "go run mage.go -v Deploy"
 
 [build.environment]
-  HUGO_VERSION = "0.107.0"
+  HUGO_VERSION = "0.111.3"
   NODE_VERSION = "12.20.0"
 
 [context.branch-deploy]

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM klakegg/hugo:0.107.0-ext-alpine
+FROM klakegg/hugo:0.111.3-ext-alpine
 
 # Cache go modules
 WORKDIR /tmp/website


### PR DESCRIPTION
Step needed to migrate away from `Git submodules` to `Hugo modules` as discussed in issue #402 
