### PR TITLE
update copa slack channel

### DIFF
--- a/website/data/projects.json
+++ b/website/data/projects.json
@@ -652,7 +652,7 @@
         "logo": "https://landscape.cncf.io/logos/012ec2df51a4bfd3fb65ede4c16c4dd2a79c585bbd057a30fadf7e233d4f5238.svg",
         "twitter": null,
         "crunchbase": "https://www.crunchbase.com/organization/cloud-native-computing-foundation",
-        "chat_channel": "#copa",
+        "chat_channel": "#copacetic",
         "accepted": "2023-09-19",
         "dev_stats_url": "https://copacetic.devstats.cncf.io/",
         "artwork_url": "https://github.com/cncf/artwork/tree/main/projects/copa",


### PR DESCRIPTION
updates copa slack channel to [#copacetic](https://cloud-native.slack.com/archives/C071UU5QDKJ)