### PR TITLE
fix(newsletters): update title and date for April CNPM Newsletter

### DIFF
--- a/website/content/resources/newsletters/2024-04-25-ProjectNewsletter.md
+++ b/website/content/resources/newsletters/2024-04-25-ProjectNewsletter.md
@@ -1,6 +1,6 @@
 ---
-title: Cloud Native Project Monthly (CNPM) March 2024 (KubeCon Edition)
-date: 2024-03-14
+title: Cloud Native Project Monthly (CNPM) April 2024 (KubeCon Edition)
+date: 2024-04-25
 ---
 
 ## 🗣️LFX Insights Beta Dashboard Feedback


### PR DESCRIPTION
Hi 👋  I noticed this when looking at previous newsletters for the upcoming announcement of [Dosu](https://dosu.dev/)

<img width="608" alt="Screenshot 2024-06-14 at 4 05 35 PM" src="https://github.com/cncf/tag-contributor-strategy/assets/7771049/36829cf8-d4e5-4912-9f1a-35a14d8ca9e3">
