### PR TITLE
Added a CTA to a page and improve search

### DIFF
--- a/website/assets/scss/_buttons.scss
+++ b/website/assets/scss/_buttons.scss
@@ -11,7 +11,8 @@
 	width: unset;
 }
 
-.cncf-button {
+.cncf-button,
+.cncf-button-primary {
 	color: $white;
 	background-color: $black;
 	border: 0;
@@ -34,4 +35,14 @@
 	&:hover {
 		background-color: $gray-700;
 	}
+}
+
+.cncf-button-primary {
+	background-color: $pink;
+	&:hover {
+		background-color: #c53490;
+		color: $white;
+		text-decoration: none;
+	}
+
 }

--- a/website/content/accessibility/deaf-and-hard-of-hearing/conference-best-practices.md
+++ b/website/content/accessibility/deaf-and-hard-of-hearing/conference-best-practices.md
@@ -18,6 +18,16 @@ While the checklist provides a meticulous list of action items, this detailed do
 
 **Note**: This document is open source. If we missed anything, please submit a pull request or issue so we can update it — thank you! 
 
+<div class="section-group">
+{{% blocks/section color="gray-300" %}}
+  <h3>Get your Accessbile Conference Checklist</h3>
+  <p>To make it really easy, we've captured everything in this document in an event checklist.</p>
+    <a class="cncf-button-primary" href="https://docs.google.com/spreadsheets/d/1lC1woVTu8YNWykCJ2FwBgy3aJEWbVUP0cZT3-Nw1hj0/edit#gid=0">
+    Download Checklist
+    </a>
+{{% /blocks/section %}}
+</div>
+
 ## General information
 
 ### DEIA: Diversity + Equity + Inclusion + Accessibility

--- a/website/layouts/_default/search.html
+++ b/website/layouts/_default/search.html
@@ -55,7 +55,7 @@
 
 		var newUrl = baseUrl + "?" + urlParams.toString();
 		// Update the browser history (optional)
-		window.history.pushState({}, null, newUrl);
+		history.replaceState(null, '', newUrl);
 	}
 	</script>
 	


### PR DESCRIPTION
See #668

Preview is towards the top of [this page](https://deploy-preview-669--cncf-contribute.netlify.app/accessibility/deaf-and-hard-of-hearing/conference-best-practices/)

It also includes a fix to avoid storing search increments in the browser history. Currently when you refine your search term, each additional edit get stored in the browser history so that clicking Back will only take you to the previous edit. This eliminates that storage so that clicking Back will take the user to the previous page.