### PR TITLE
Update contributors

### DIFF
--- a/valued-members.md
+++ b/valued-members.md
@@ -1,6 +1,6 @@
 # Valued TAG Members
 
-### Original Bootstrap TAG members
+## Original Bootstrap TAG members
 
 - Amye Scavarda Perrin ([@amye](https://github.com/amye)), CNCF
 - April Kyle Nassi ([@thisisnotapril](https://github.com/thisisnotapril)), Google
@@ -10,13 +10,18 @@
 - Ihor Dvoretskyi ([@idvoretskyi](https://github.com/idvoretskyi)), CNCF
 - Josh Berkus ([@jberkus](https://github.com/jberkus)), Red Hat
 - Karen Chu ([@karenhchu](https://github.com/karenhchu)), Microsoft
+- Ken Owens ([@kow3ns](https://github.com/kow3ns))
+- Liz Rice ([@lizrice](https://github.com/lizrice)), Isovalent
+- Matt Farina ([@mattfarina](https://github.com/mattfarina)), Suse
+- Matt Jarvis
 - Matt Klein ([@mattklein123](https://github.com/mattklein123)), Lyft
 - Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple
 - Saad Ali ([@saad-ali](https://github.com/saad-ali)), Google
+- Sarah Allen ([@ultrasaurus](https://github.com/ultrasaurus))
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco
 - Zach Corleissen ([@zacharysarah](https://github.com/zacharysarah)), Linux Foundation
 
-### Emeritus Leads
+## Emeritus Leads
 
 - Carolyn Van Slyck ([@carolynvs](https://github.com/carolynvs)), Microsoft
 - Gerred Dillon ([@gerred](https://github.com/gerred)), Defense Unicorns


### PR DESCRIPTION
As part of cleaning up the TAG charter in the TOC repo I am moving the historical attribution from the charter to the TAG repo to ensure it is not lost.