### PR TITLE
Update projects.json - Score

### DIFF
--- a/website/data/projects.json
+++ b/website/data/projects.json
@@ -3629,10 +3629,10 @@
         "stack_overflow_url": null,
         "blog_url": "https://score.dev/blog",
         "mailing_list_url": null,
-        "slack_url": null,
+        "slack_url": "https://cloud-native.slack.com/archives/C07DN0D1UCW",
         "gitter_url": null,
         "youtube_url": null,
-        "language": "Makefile"
+        "language": "Go"
     },
     {
         "name": "sealer",

--- a/website/data/projects.json
+++ b/website/data/projects.json
@@ -3625,7 +3625,7 @@
         "chat_channel": null,
         "accepted": "2024-07-08",
         "dev_stats_url": "https://score.devstats.cncf.io/",
-        "artwork_url": null,
+        "artwork_url": "https://github.com/cncf/artwork/tree/main/projects/score",
         "stack_overflow_url": null,
         "blog_url": "https://score.dev/blog",
         "mailing_list_url": null,


### PR DESCRIPTION
Via this PR I'm doing this manually, but guessing this could be automated or coming from somewhere else?
There is apparently this bot https://github.com/cncf/tag-contributor-strategy/pull/719 updating Projects but where is the source of this file updates?

For Score, we would need these 3 changes, do you know where upstream we could update these info?

Thanks for any pointer!