### PR TITLE
Fix charter 404

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "website/themes/docsy"]
 	path = website/themes/docsy
 	url = https://github.com/google/docsy.git
+[submodule "website/assets/cncf-toc"]
+	path = website/assets/cncf-toc
+	url = https://github.com/cncf/toc.git

--- a/website/config.toml
+++ b/website/config.toml
@@ -37,7 +37,7 @@ pygmentsStyle = "tango"
     target = "content"
   
   [[module.mounts]]
-    source = "../CHARTER.md"
+    source = "assets/cncf-toc/tags/tag-charters/contributor-strategy.md"
     target = "content/about/charter.md"
   
   [[module.mounts]]


### PR DESCRIPTION
fixes #762 

I think I did this right.

Test with:
```
$ git submodule update --init --recursive
$ npm install
$ npm run serve
$ curl -s http://localhost:1313/about/charter/ | grep -o '<h1.*</h1>'
<h1></h1><h1 id=cncf-tag-contributor-strategy-charter>CNCF TAG Contributor Strategy Charter</h1>
```