### PR TITLE
Fixed: The contributor page giving 404 Page not found error

### DIFF
--- a/website/content/resources/newsletters/2024-04-25-ProjectNewsletter.md
+++ b/website/content/resources/newsletters/2024-04-25-ProjectNewsletter.md
@@ -47,4 +47,4 @@ We’re extending the window for Term 2 project ideas. You’ve now have until M
 
 ## Contribute!
 Want to contribute to the next newsletter? 
-[Contribute Today!](projects@cncf.io)
+[Contribute Today!](https://contribute.cncf.io/contributors/projects/)


### PR DESCRIPTION
Fixed the contributor page giving 404 page not found error. Tried to fix #732 
