### PR TITLE
Add BVI "using slack with a screen reader" tips

### DIFF
--- a/website/content/accessibility/blind-and-visually-impaired/using-slack-with-a-screen-reader.md
+++ b/website/content/accessibility/blind-and-visually-impaired/using-slack-with-a-screen-reader.md
@@ -1,0 +1,28 @@
+---
+title: "Using Slack With a Screen Reader"
+date: 2025-06-31
+description: >
+  Tips to help screen reader users use the Slack messaging application
+---
+
+The [Slack screen reader web page](https://slack.com/intl/en-in/help/articles/360000411963-Use-Slack-with-a-screen-reader) provides a good introduction to Slack concepts and walks through navigating, replying to, and adding a reaction to messages and screen reader-specific preferences in the Slack application.
+
+There are a myriad of keyboard shortcuts — see the [Slack keyboard shortcuts](https://slack.com/help/articles/201374536-Slack-keyboard-shortcuts) page for the complete list for Windows, Linux, and Mac.
+
+The [Slack accessibility YouTube playlist](https://www.youtube.com/playlist?list=PLWlXaxtQ7fUbLVoC2vLrELjD9VXb-YA_0) includes videos about general navigation, reading and replying to messages, using threads, and using message actions like reactions. If you are new to Slack, their videos about [navigating with JAWS](https://www.youtube.com/watch?v=v8O8xrl6oas&list=PLWlXaxtQ7fUbLVoC2vLrELjD9VXb-YA_0&index=3) or [navigating with VoiceOver](https://www.youtube.com/watch?v=haPAbkLLDME&list=PLWlXaxtQ7fUbLVoC2vLrELjD9VXb-YA_0&index=4) provide a good narrated introduction to your options for navigating the Slack window.
+
+Building on the above resources, here are some recommended practices to help fast-track your Slack journey:
+
+* The Slack application will provide a better experience and more keyboard hotkeys than the web UI.  
+* Slack behaves more like an application than a web page — for example, using up/down arrow keys to navigate a message list, right/left arrows to expand/collapse a thread, and Tab / Shift-Tab to navigate elements of a message.  
+* JAWS and NVDA users are recommended to navigate in focus/forms mode instead of browse mode.  
+* VoiceOver users may have a less frustrating experience by making sure the mouse pointer is configured to ignore the VoiceOver cursor, because Slack sometimes triggers popups when the mouse pointer hovers over an item. This VoiceOver setting is in the VoiceOver Utility \-\> Navigation category \-\> “Mouse pointer.” You can also change this setting only for the Slack application by creating a VoiceOver “activity” for Slack.  
+* The quick switcher (Ctrl-k on Windows, Command-k on Mac) is a fast way to search for and jump to a channel or direct message.  
+* Use Ctrl-j (Windows) or Command-j (Mac) to jump to the first unread message of a conversation.  
+* Use Alt-Shift-Down-arrow (Windows) or Option-Shift-Down-arrow (Mac) to jump to the next unread channel or direct message.  
+* Move back and forth in the history of conversations you’ve visited with Alt-left/right arrows (use Command instead on Mac).  
+* Jump to the threads view with Control-Shift-t (Windows) or Command-Shift-t (Mac)—this shows all of the threads you’re in, in a single message list. You can jump to the edit field at the bottom of a thread by typing a character that is not assigned to a Slack shortcut while reading a message in that thread.  
+* To quickly upload a file, use the Control-u (Windows) or Cmd-u (Mac) shortcut. The edit field that’s shown after you select the file to be uploaded is a comment that will show up with that file in the message list.  
+* It’s possible to [use markdown formatting when composing a message](https://slack.com/help/articles/202288908-Format-your-messages) by using the Control-Shift-f (Windows) or Command-Shift-f (Mac) shortcut or enabling it permanently in Slack preferences.
+
+We hope these tips are useful. This page is open source, so if you have any additional tips or even a correction, please submit a pull request\!   


### PR DESCRIPTION
Add a document to help visually impaired folks navigate Slack using a screen reader. This document is intended to highlight the value of existing online resources, and provide a few quick tips to help users maximize their experience.

The idea and content for this document is not mine alone, see also [the SLack blind and visually impaired channel](https://cloud-native.slack.com/archives/C07CPG6AFC7/p1737558791923419).
