### PR TITLE
Fix broken Website Guidelines link on CNCF Maintainers page

### DIFF
--- a/website/content/maintainers/community/vendor-neutrality.md
+++ b/website/content/maintainers/community/vendor-neutrality.md
@@ -20,7 +20,7 @@ Many adopters may be interested in commercial support for CNCF projects, but may
 
 ### Websites
 
-* Please refer to the CNCF [website guidelines](https://github.com/cncf/foundation/blob/main/website-guidelines.md)
+* Please refer to the CNCF [website guidelines](https://github.com/cncf/foundation/blob/main/policies-guidance/website-guidelines.md)
 
 ### Blogs
 


### PR DESCRIPTION
This PR fixes a broken link on the CNCF Contributors page under:  
`Maintainer > Community > Vendor neutrality`

### Changes Made
- Updated the **Website Guidelines** link from:  
  `https://github.com/cncf/foundation/blob/main/website-guidelines.md`  
  ➝ to:  
  `https://github.com/cncf/foundation/blob/main/policies-guidance/website-guidelines.md`

Closes #820